### PR TITLE
28 standarize decimal responses

### DIFF
--- a/Connector/bch/apirpc.py
+++ b/Connector/bch/apirpc.py
@@ -129,12 +129,12 @@ def getAddressUnspent(id, params):
 
         response.append({
             TX_HASH: tx[TX_HASH_SNAKE_CASE],
-            VOUT: str(tx[TX_POS_SNAKE_CASE]),
+            VOUT: tx[TX_POS_SNAKE_CASE],
             STATUS: {
                 CONFIRMED: tx[HEIGHT] != 0,
-                BLOCK_HEIGHT: str(tx[HEIGHT])
+                BLOCK_HEIGHT: tx[HEIGHT]
             },
-            VALUE: str(tx[VALUE])
+            VALUE: tx[VALUE]
         })
 
     err = rpcutils.validateJSONRPCSchema(response, responseSchema)
@@ -177,12 +177,7 @@ def getBlockByNumber(id, params):
     if err is not None:
         raise rpcerrorhandler.BadRequestError(err.message)
 
-    try:
-        blockNumber = int(params[BLOCK_NUMBER], base=10)
-    except Exception as err:
-        raise rpcerrorhandler.BadRequestError(str(err))
-
-    blockHash = RPCConnector.request(RPC_CORE_ENDPOINT, id, GET_BLOCK_HASH_METHOD, [blockNumber])
+    blockHash = RPCConnector.request(RPC_CORE_ENDPOINT, id, GET_BLOCK_HASH_METHOD, [params[BLOCK_NUMBER]])
 
     return getBlockByHash(id, {BLOCK_HASH: blockHash})
 
@@ -199,14 +194,9 @@ def getFeePerByte(id, params):
     if err is not None:
         raise rpcerrorhandler.BadRequestError(err.message)
 
-    try:
-        confirmations = int(params[CONFIRMATIONS], base=10)
-    except ValueError as err:
-        raise rpcerrorhandler.BadRequestError(str(err))
-
     feePerByte = RPCConnector.request(RPC_CORE_ENDPOINT, id,
                                       ESTIMATE_SMART_FEE_METHOD,
-                                      [confirmations])
+                                      [params[CONFIRMATIONS]])
 
     response = {FEE_PER_BYTE: utils.convertToSatoshi(feePerByte[FEE_RATE])}
 
@@ -321,7 +311,7 @@ def getTransactionCount(id, params):
 
     response = {
         TRANSACTION_COUNT:
-        str(pending) if params[PENDING] else str(len(txs) - pending)
+        pending if params[PENDING] else (len(txs) - pending)
     }
 
     err = rpcutils.validateJSONRPCSchema(response, responseSchema)

--- a/Connector/bch/rpcschemas/getaddressbalance_response.json
+++ b/Connector/bch/rpcschemas/getaddressbalance_response.json
@@ -11,10 +11,10 @@
             "type": "object",
             "properties": {
                 "confirmed": {
-                    "type": "string"
+                    "type": "integer"
                 },
                 "unconfirmed": {
-                    "type": "string"
+                    "type": "integer"
                 }
             },
             "required": [

--- a/Connector/bch/rpcschemas/getaddressesbalance_response.json
+++ b/Connector/bch/rpcschemas/getaddressesbalance_response.json
@@ -13,10 +13,10 @@
                 "type": "object",
                 "properties": {
                     "confirmed": {
-                        "type": "string"
+                        "type": "integer"
                     },
                     "unconfirmed": {
-                        "type": "string"
+                        "type": "integer"
                     }
                 },
                 "required": [

--- a/Connector/bch/rpcschemas/getaddressunspent_response.json
+++ b/Connector/bch/rpcschemas/getaddressunspent_response.json
@@ -10,7 +10,7 @@
                 "type": "string"
             },
             "vout": {
-                "type": "string"
+                "type": "integer"
             },
             "status": {
                 "type": "object",
@@ -19,7 +19,7 @@
                         "type": "boolean"
                     },
                     "blockHeight": {
-                        "type": "string"
+                        "type": "integer"
                     }
                 },
                 "required": [
@@ -28,7 +28,7 @@
                 ]
             },
             "value": {
-                "type" : "string"
+                "type" : "integer"
             }
         },
         "required": [

--- a/Connector/bch/rpcschemas/getblockbynumber_request.json
+++ b/Connector/bch/rpcschemas/getblockbynumber_request.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "blockNumber" : {
-            "type": "string"
+            "type": "integer"
         }
     },
     "required": [

--- a/Connector/bch/rpcschemas/getfeeperbyte_request.json
+++ b/Connector/bch/rpcschemas/getfeeperbyte_request.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "confirmations" : {
-            "type" : "string"
+            "type" : "integer"
         }
     },
     "required": [

--- a/Connector/bch/rpcschemas/getfeeperbyte_response.json
+++ b/Connector/bch/rpcschemas/getfeeperbyte_response.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "feePerByte" : {
-            "type" : "string"
+            "type" : "integer"
         }
     },
     "required": [

--- a/Connector/bch/rpcschemas/gettransactioncount_response.json
+++ b/Connector/bch/rpcschemas/gettransactioncount_response.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "transactionCount" : {
-            "type" : "string"
+            "type" : "integer"
         }
     },
     "required": [

--- a/Connector/bch/rpcschemas/syncing_response.json
+++ b/Connector/bch/rpcschemas/syncing_response.json
@@ -11,10 +11,10 @@
             "type": "string"
         },
         "currentBlock":{
-            "type": "string"
+            "type": "integer"
         },
         "latestBlock":{
-            "type": "string"
+            "type": "integer"
         }
     },
     "required": [

--- a/Connector/bch/utils.py
+++ b/Connector/bch/utils.py
@@ -4,7 +4,7 @@ from .constants import *
 
 
 def convertToSatoshi(strAmount):
-    return str(int(Decimal(strAmount) * 100000000))
+    return int(Decimal(strAmount) * 100000000)
 
 
 def getMethodSchemas(name):

--- a/Connector/btc/apirpc.py
+++ b/Connector/btc/apirpc.py
@@ -128,7 +128,7 @@ def getAddressUnspent(id, params):
 
         response.append({
             TX_HASH: tx[TX_HASH_SNAKE_CASE],
-            VOUT: str(tx[TX_POS_SNAKE_CASE]),
+            VOUT: tx[TX_POS_SNAKE_CASE],
             STATUS: {
                 CONFIRMED: tx[HEIGHT] != 0,
                 BLOCK_HEIGHT: tx[HEIGHT]

--- a/Connector/btc/apirpc.py
+++ b/Connector/btc/apirpc.py
@@ -131,9 +131,9 @@ def getAddressUnspent(id, params):
             VOUT: str(tx[TX_POS_SNAKE_CASE]),
             STATUS: {
                 CONFIRMED: tx[HEIGHT] != 0,
-                BLOCK_HEIGHT: str(tx[HEIGHT])
+                BLOCK_HEIGHT: tx[HEIGHT]
             },
-            VALUE: str(tx[VALUE])
+            VALUE: tx[VALUE]
         })
 
     err = rpcutils.validateJSONRPCSchema(response, responseSchema)
@@ -178,12 +178,7 @@ def getBlockByNumber(id, params):
     if err is not None:
         raise rpcerrorhandler.BadRequestError(err.message)
 
-    try:
-        blockNumber = int(params[BLOCK_NUMBER], base=10)
-    except Exception as err:
-        raise rpcerrorhandler.BadRequestError(str(err))
-
-    blockHash = RPCConnector.request(RPC_CORE_ENDPOINT, id, GET_BLOCK_HASH_METHOD, [blockNumber])
+    blockHash = RPCConnector.request(RPC_CORE_ENDPOINT, id, GET_BLOCK_HASH_METHOD, [params[BLOCK_NUMBER]])
 
     return getBlockByHash(id, {BLOCK_HASH: blockHash})
 
@@ -201,14 +196,9 @@ def getFeePerByte(id, params):
     if err is not None:
         raise rpcerrorhandler.BadRequestError(err.message)
 
-    try:
-        confirmations = int(params[CONFIRMATIONS], base=10)
-    except ValueError as err:
-        raise rpcerrorhandler.BadRequestError(str(err))
-
     feePerByte = RPCConnector.request(RPC_CORE_ENDPOINT, id,
                                       ESTIMATE_SMART_FEE_METHOD,
-                                      [confirmations])
+                                      [params[CONFIRMATIONS]])
 
     if FEE_RATE not in feePerByte:
         logger.printError(f"Response without {FEE_RATE}. No feerate found")
@@ -331,7 +321,7 @@ def getTransactionCount(id, params):
 
     response = {
         TRANSACTION_COUNT:
-        str(pending) if params[PENDING] else str(len(txs) - pending)
+        pending if params[PENDING] else (len(txs) - pending)
     }
 
     err = rpcutils.validateJSONRPCSchema(response, responseSchema)

--- a/Connector/btc/rpcschemas/getaddressbalance_response.json
+++ b/Connector/btc/rpcschemas/getaddressbalance_response.json
@@ -11,10 +11,10 @@
             "type": "object",
             "properties": {
                 "confirmed": {
-                    "type": "string"
+                    "type": "integer"
                 },
                 "unconfirmed": {
-                    "type": "string"
+                    "type": "integer"
                 }
             },
             "required": [

--- a/Connector/btc/rpcschemas/getaddressesbalance_response.json
+++ b/Connector/btc/rpcschemas/getaddressesbalance_response.json
@@ -13,10 +13,10 @@
                 "type": "object",
                 "properties": {
                     "confirmed": {
-                        "type": "string"
+                        "type": "integer"
                     },
                     "unconfirmed": {
-                        "type": "string"
+                        "type": "integer"
                     }
                 },
                 "required": [

--- a/Connector/btc/rpcschemas/getaddressunspent_response.json
+++ b/Connector/btc/rpcschemas/getaddressunspent_response.json
@@ -19,7 +19,7 @@
                         "type": "boolean"
                     },
                     "blockHeight": {
-                        "type": "string"
+                        "type": "integer"
                     }
                 },
                 "required": [
@@ -28,7 +28,7 @@
                 ]
             },
             "value": {
-                "type" : "string"
+                "type" : "integer"
             }
         },
         "required": [

--- a/Connector/btc/rpcschemas/getaddressunspent_response.json
+++ b/Connector/btc/rpcschemas/getaddressunspent_response.json
@@ -10,7 +10,7 @@
                 "type": "string"
             },
             "vout": {
-                "type": "string"
+                "type": "integer"
             },
             "status": {
                 "type": "object",

--- a/Connector/btc/rpcschemas/getblockbynumber_request.json
+++ b/Connector/btc/rpcschemas/getblockbynumber_request.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "blockNumber" : {
-            "type": "string"
+            "type": "integer"
         }
     },
     "required": [

--- a/Connector/btc/rpcschemas/getfeeperbyte_request.json
+++ b/Connector/btc/rpcschemas/getfeeperbyte_request.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "confirmations" : {
-            "type" : "string"
+            "type" : "integer"
         }
     },
     "required": [

--- a/Connector/btc/rpcschemas/getfeeperbyte_response.json
+++ b/Connector/btc/rpcschemas/getfeeperbyte_response.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "feePerByte" : {
-            "type" : "string"
+            "type" : "integer"
         }
     },
     "required": [

--- a/Connector/btc/rpcschemas/gettransactioncount_response.json
+++ b/Connector/btc/rpcschemas/gettransactioncount_response.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "transactionCount" : {
-            "type" : "string"
+            "type" : "integer"
         }
     },
     "required": [

--- a/Connector/btc/rpcschemas/syncing_response.json
+++ b/Connector/btc/rpcschemas/syncing_response.json
@@ -11,10 +11,10 @@
             "type": "string"
         },
         "currentBlock":{
-            "type": "string"
+            "type": "integer"
         },
         "latestBlock":{
-            "type": "string"
+            "type": "integer"
         }
     },
     "required": [

--- a/Connector/btc/utils.py
+++ b/Connector/btc/utils.py
@@ -10,7 +10,7 @@ from . import apirpc
 
 
 def convertToSatoshi(strAmount):
-    return str(int(Decimal(strAmount) * 100000000))
+    return int(Decimal(strAmount) * 100000000)
 
 
 def getMethodSchemas(name):

--- a/Connector/eth/apirpc.py
+++ b/Connector/eth/apirpc.py
@@ -33,7 +33,7 @@ def getAddressBalance(id, params):
         ADDRESS: params[ADDRESS],
         BALANCE: {
             CONFIRMED: utils.toWei(connPending),
-            UNCONFIRMED: utils.toWei(connPending) - utils.toWei(connLatest, 16)
+            UNCONFIRMED: utils.toWei(connPending) - utils.toWei(connLatest)
         }
     }
 

--- a/Connector/eth/rpcschemas/estimategas_response.json
+++ b/Connector/eth/rpcschemas/estimategas_response.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "estimatedGas": {
-            "type": "string"
+            "type": "integer"
         }
     },
     "required": [

--- a/Connector/eth/rpcschemas/getaddressbalance_response.json
+++ b/Connector/eth/rpcschemas/getaddressbalance_response.json
@@ -11,10 +11,10 @@
             "type": "object",
             "properties": {
                 "confirmed": {
-                    "type": "string"
+                    "type": "integer"
                 },
                 "unconfirmed": {
-                    "type": "string"
+                    "type": "integer"
                 }
             },
             "required": [

--- a/Connector/eth/rpcschemas/getaddressesbalance_response.json
+++ b/Connector/eth/rpcschemas/getaddressesbalance_response.json
@@ -13,10 +13,10 @@
                 "type": "object",
                 "properties": {
                     "confirmed": {
-                        "type": "string"
+                        "type": "integer"
                     },
                     "unconfirmed": {
-                        "type": "string"
+                        "type": "integer"
                     }
                 },
                 "required": [

--- a/Connector/eth/rpcschemas/getblockbynumber_request.json
+++ b/Connector/eth/rpcschemas/getblockbynumber_request.json
@@ -5,7 +5,10 @@
     "type": "object",
     "properties": {
         "blockNumber": {
-            "type": "string"
+            "type": [
+                "string",
+                "integer"
+            ]
         }
     },
     "required": [

--- a/Connector/eth/rpcschemas/getgasprice_response.json
+++ b/Connector/eth/rpcschemas/getgasprice_response.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "gasPrice": {
-            "type": "string"
+            "type": "integer"
         }
     },
     "required": [

--- a/Connector/eth/rpcschemas/getheight_response.json
+++ b/Connector/eth/rpcschemas/getheight_response.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "latestBlockIndex": {
-            "type": "string"
+            "type": "integer"
         },
         "latestBlockHash"  : {
             "type" : "string"

--- a/Connector/eth/rpcschemas/gettransaction_response.json
+++ b/Connector/eth/rpcschemas/gettransaction_response.json
@@ -63,7 +63,7 @@
                         "type": "string"
                     },
                     "amount": {
-                        "type": "string"
+                        "type": "integer"
                     }
                 }
             }
@@ -80,7 +80,7 @@
                         ]
                     },
                     "amount": {
-                        "type": "string"
+                        "type": "integer"
                     }
                 }
             }

--- a/Connector/eth/rpcschemas/gettransactioncount_response.json
+++ b/Connector/eth/rpcschemas/gettransactioncount_response.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "transactionCount" : {
-            "type" : "string"
+            "type" : "integer"
         }
     },
     "required": [

--- a/Connector/eth/rpcschemas/syncing_response.json
+++ b/Connector/eth/rpcschemas/syncing_response.json
@@ -11,10 +11,10 @@
             "type": "string"
         },
         "currentBlock":{
-            "type": "string"
+            "type": "integer"
         },
         "latestBlock":{
-            "type": "string"
+            "type": "integer"
         }
     },
     "required": [

--- a/Connector/eth/utils.py
+++ b/Connector/eth/utils.py
@@ -50,3 +50,7 @@ def getSyncPercentage(currentBlock, latestBlock):
 
 def closingAddrBalanceTopic(topicName):
     logger.printInfo(f"No need to handle topic [{topicName}] close")
+
+
+def toWei(amount):
+    return int(amount, 16)

--- a/Connector/tests/btc/test_btc.py
+++ b/Connector/tests/btc/test_btc.py
@@ -348,7 +348,7 @@ def testGetAddressUnspent():
         txs.append(
             {
                 TX_HASH: tx[TX_HASH_SNAKE_CASE],
-                VOUT: str(tx[TX_POS_SNAKE_CASE]),
+                VOUT: tx[TX_POS_SNAKE_CASE],
                 STATUS: {
                     CONFIRMED: tx[HEIGHT] != 0,
                     BLOCK_HEIGHT: tx[HEIGHT]

--- a/Connector/tests/btc/test_btc.py
+++ b/Connector/tests/btc/test_btc.py
@@ -157,7 +157,7 @@ def testGetBlock():
         assert False
 
     gotByNumber = RPCMethods["getBlockByNumber"](0, {
-        BLOCK_NUMBER: str(blockNumber)
+        BLOCK_NUMBER: blockNumber
     })
 
     if not json.dumps(expectedBlock, sort_keys=True) == json.dumps(gotByNumber, sort_keys=True):
@@ -192,10 +192,10 @@ def testGetFeePerByte():
     confirmations = 2
     expected = makeBitcoinCoreRequest(ESTIMATE_SMART_FEE_METHOD, [confirmations])
     got = RPCMethods["getFeePerByte"](0, {
-        CONFIRMATIONS: str(confirmations)
+        CONFIRMATIONS: confirmations
     })
 
-    assert str(expected[FEE_RATE]) == str(float((Decimal(got[FEE_PER_BYTE]) / 100000000)))
+    assert expected[FEE_RATE] == float((Decimal(got[FEE_PER_BYTE]) / 100000000))
 
 
 def testBroadcastTransaction():
@@ -327,7 +327,7 @@ def testGetTransactionCount():
         if tx[HEIGHT] == 0:
             pendingCount += 1
 
-    assert got[TRANSACTION_COUNT] == str(pendingCount) if pending else str(len(expected) - pendingCount)
+    assert got[TRANSACTION_COUNT] == pendingCount if pending else (len(expected) - pendingCount)
 
 
 def testGetAddressUnspent():
@@ -351,9 +351,9 @@ def testGetAddressUnspent():
                 VOUT: str(tx[TX_POS_SNAKE_CASE]),
                 STATUS: {
                     CONFIRMED: tx[HEIGHT] != 0,
-                    BLOCK_HEIGHT: str(tx[HEIGHT])
+                    BLOCK_HEIGHT: tx[HEIGHT]
                 },
-                VALUE: str(tx[VALUE])
+                VALUE: tx[VALUE]
             }
         )
 

--- a/Connector/tests/eth/test_eth.py
+++ b/Connector/tests/eth/test_eth.py
@@ -70,7 +70,7 @@ def testGetAddressBalance():
 
     got = RPCMethods["getAddressBalance"](0, {"address": address1})
 
-    assert got[BALANCE][CONFIRMED] == expectedPending and got[BALANCE][UNCONFIRMED] == (hex(int(expectedPending, 16) - int(expectedLatest, 16))) and address1 == got[ADDRESS]
+    assert got[BALANCE][CONFIRMED] == int(expectedPending, 16) and got[BALANCE][UNCONFIRMED] == (int(expectedPending, 16) - int(expectedLatest, 16)) and address1 == got[ADDRESS]
 
 
 def testGetAddressesBalance():
@@ -99,7 +99,7 @@ def testGetAddressesBalance():
 
             if gotBalance[ADDRESS] == address:
                 found = True
-                if not (gotBalance[BALANCE][CONFIRMED] == expectedPending and gotBalance[BALANCE][UNCONFIRMED] == (hex(int(expectedPending, 16) - int(expectedLatest, 16)))):
+                if not (gotBalance[BALANCE][CONFIRMED] == int(expectedPending, 16) and gotBalance[BALANCE][UNCONFIRMED] == (int(expectedPending, 16) - int(expectedLatest, 16))):
                     logger.printError(f"Error validating {address}")
                     assert False
         if not found:
@@ -122,7 +122,7 @@ def testGetHeight():
         [LATEST, True]
     )
 
-    assert expected[NUMBER] == got[LATEST_BLOCK_INDEX] and expected[HASH] == got[LATEST_BLOCK_HASH]
+    assert int(expected[NUMBER], 16) == got[LATEST_BLOCK_INDEX] and expected[HASH] == got[LATEST_BLOCK_HASH]
 
 
 def testGetTransaction():
@@ -147,12 +147,12 @@ def testGetTransaction():
             logger.printError("Transaction data not correct")
             assert False
     for input in got[INPUTS]:
-        if input[ADDRESS] != expected[FROM] or input[AMOUNT] != expected[VALUE]:
+        if input[ADDRESS] != expected[FROM] or input[AMOUNT] != int(expected[VALUE], 16):
             logger.printError(f"Transaction input not correct. Output address: {input[ADDRESS]} Expected: {expected[FROM]} Output ampount: {input[AMOUNT]} Expected: {expected[VALUE]}")
             assert False
 
     for output in got[OUTPUTS]:
-        if output[ADDRESS] != expected[TO] or output[AMOUNT] != expected[VALUE]:
+        if output[ADDRESS] != expected[TO] or output[AMOUNT] != int(expected[VALUE], 16):
             logger.printError(f"Transaction output not correct. Output address: {output[ADDRESS]} Expected: {expected[TO]} Output ampount: {output[AMOUNT]} Expected: {expected[VALUE]}")
             assert False
 
@@ -182,7 +182,7 @@ def testEstimateGas():
     })
     expected = makeEtherumgoRequest(ESTIMATE_GAS_METHOD, [tx])
 
-    assert got[ESTIMATED_GAS] == expected
+    assert got[ESTIMATED_GAS] == int(expected, 16)
 
 
 def testGetGasPrice():
@@ -199,7 +199,7 @@ def testGetGasPrice():
         None
     )
 
-    assert expected == got[GAS_PRICE]
+    assert int(expected, 16) == got[GAS_PRICE]
 
 
 def testGetTransactionReceipt():
@@ -235,7 +235,7 @@ def testGetTransactionCount():
     })
     expected = makeEtherumgoRequest(GET_TRANSACTION_COUNT_METHOD, [address1, PENDING])
 
-    assert got[TRANSACTION_COUNT] == expected
+    assert got[TRANSACTION_COUNT] == int(expected, 16)
 
 
 def testGetBlock():


### PR DESCRIPTION
# Description
To standardize all responses that return a decimal number it is proposed to return all such responses in JSON number type.

Due to the poor implementation of the standard number type in languages like Javascript it may cause some problems in the future to return data as Number instead of String.
<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

### BTC
- [x] getAddressBalance
- [x] getAddressesBalance
- [x] getAddressUnspent
- [x] getBlockByNumber
- [x] getFeePerByte
- [x] getTransactionCount
- [x] syncing

### BCH
- [x] getAddressBalance
- [x] getAddressUnspent
- [x] getBlockByNumber
- [x] getFeePerByte
- [x] getTransactionCount
- [x] syncing

### ETH
- [x] estimateGas
- [x] getAddressBalance
- [x] getAddressesBalance
- [x] getBlockByNumber
- [x] getGasPrice
- [x] getHeight
- [x] getTransaction
- [x] getTransactionCount
- [x] syncing


Fixes #28 (issue)

## Dependencies (if any)

<!--List any dependencies that are required for this change.-->

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **This change requires a documentation update**

# How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. -->
<!--Provide instructions so we can reproduce the changes, if possible add screenshots, gifs or logs to facilitate the work.-->
<!--Please also list any relevant details for your test configuration.-->

Test has been passed for ETH and BTC:
![imagen](https://user-images.githubusercontent.com/75782378/147615495-5539818f-f6d7-49ef-b748-a9fe52bc18bc.png)

Syncing method tested separately
```sh
curl -X POST --header 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"syncing","params":{}, "id":1}' http://localhost:60001/rpc

{"id": 1, "jsonrpc": "2.0", "result": {"syncing": true, "syncPercentage": "0.038334007004731815%", "currentBlockIndex": 13160, "latestBlockIndex": 2133529}}
```

**Test Configuration**:
* Operating system (output of `cat /etc/os-release`):
```sh
NAME="Ubuntu"
VERSION="18.04.5 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.5 LTS"
VERSION_ID="18.04"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
```
* Kernel version (output of `uname -sr`): Linux 4.15.0-143-generic
* Architecture (output of `uname -m`): x86_64

# Related PR or Docs PR

<!--Please add any related Pull Requests here. -->
Docs PR related # <!--(if any)-->
Other PR related swapper-org/swapper-core#25  <!--(if any)-->

# Good practices to consider

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules