### PR TITLE
HTTP and RPC response headers updated

### DIFF
--- a/Connector/httputils/httputils.py
+++ b/Connector/httputils/httputils.py
@@ -27,14 +27,20 @@ def postMethod(function):
 
             return web.Response(
                 text=json.dumps(response),
-                content_type=rpcutils.JSON_CONTENT_TYPE
+                content_type=rpcutils.JSON_CONTENT_TYPE,
+                headers={
+                    "Access-Control-Allow-Origin": "*"
+                }
             )
 
         except errorhandler.Error as e:
             return web.Response(
                 text=json.dumps(e.jsonEncode()),
                 content_type=rpcutils.JSON_CONTENT_TYPE,
-                status=e.code
+                status=e.code,
+                headers={
+                    "Access-Control-Allow-Origin": "*"
+                }
             )
 
     app = WebApp()
@@ -62,14 +68,20 @@ def getMethod(function):
 
             return web.Response(
                 text=json.dumps(response),
-                content_type=rpcutils.JSON_CONTENT_TYPE
+                content_type=rpcutils.JSON_CONTENT_TYPE,
+                headers={
+                    "Access-Control-Allow-Origin": "*"
+                }
             )
 
         except errorhandler.Error as e:
             return web.Response(
                 text=json.dumps(e.jsonEncode()),
                 content_type=rpcutils.JSON_CONTENT_TYPE,
-                status=e.code
+                status=e.code,
+                headers={
+                    "Access-Control-Allow-Origin": "*"
+                }
             )
 
     app = WebApp()

--- a/Connector/server.py
+++ b/Connector/server.py
@@ -42,7 +42,10 @@ async def rpcServerHandler(request):
             text=json.dumps(
                 response
             ),
-            content_type=rpcutils.JSON_CONTENT_TYPE
+            content_type=rpcutils.JSON_CONTENT_TYPE,
+            headers={
+                "Access-Control-Allow-Origin": "*"
+            }
         )
 
     except rpcErrorHandler.Error as e:
@@ -59,7 +62,10 @@ async def rpcServerHandler(request):
                 response
             ),
             content_type=rpcutils.JSON_CONTENT_TYPE,
-            status=e.code
+            status=e.code,
+            headers={
+                "Access-Control-Allow-Origin": "*"
+            }
         )
 
 


### PR DESCRIPTION
# Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

The headers Access-Control-Allow-Origin': '*' has been added in API responses for supporting CORS in browsers.

Fixes #53

## Dependencies (if any)

<!--List any dependencies that are required for this change.-->

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **This change requires a documentation update**

# How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. -->
<!--Provide instructions so we can reproduce the changes, if possible add screenshots, gifs or logs to facilitate the work.-->
<!--Please also list any relevant details for your test configuration.-->

- HTTP Get Height
```
curl -v --location --request GET 'http://localhost:80/getHeight'
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 80 (#0)
> GET /getHeight HTTP/1.1
> Host: localhost
> User-Agent: curl/7.60.0
> Accept: */*
> 
< HTTP/1.1 200 OK
<Access-Control-Allow-Origin: *
< Content-Type: application/json; charset=utf-8
< Content-Length: 110
< Date: Sun, 09 Jan 2022 16:50:24 GMT
< Server: Python/3.7 aiohttp/3.7.2
< 
* Connection #0 to host localhost left intact
{"latestBlockIndex": 1, "latestBlockHash": "79b983e73e04f6dcbe4ae22302af6d5e4f9eeb31a3f593f59e3e4ad36fb7b153"}
```

- RPC Get Height
```
curl --location -v  --request POST 'http://localhost:80/rpc' --header 'Content-Type: application/json' --data-raw '{
    "id": 1609070896412,
    "method": "getHeight",
    "params": {},
    "jsonrpc": "2.0"
}'
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 80 (#0)
> POST /rpc HTTP/1.1
> Host: localhost
> User-Agent: curl/7.60.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 94
> 
* upload completely sent off: 94 out of 94 bytes
< HTTP/1.1 200 OK
< Access-Control-Allow-Origin: *
< Content-Type: application/json; charset=utf-8
< Content-Length: 161
< Date: Sun, 09 Jan 2022 16:56:10 GMT
< Server: Python/3.7 aiohttp/3.7.2
< 
* Connection #0 to host localhost left intact
{"id": 1609070896412, "jsonrpc": "2.0", "result": {"latestBlockIndex": 1, "latestBlockHash": "79b983e73e04f6dcbe4ae22302af6d5e4f9eeb31a3f593f59e3e4ad36fb7b153"}}(
```

**Test Configuration**:
Operating system (output of sw_vers): macOS 12.0.1

# Good practices to consider

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules