### PR TITLE
Update bitcoin core with default wallet creation

### DIFF
--- a/.availableCurrencies.json
+++ b/.availableCurrencies.json
@@ -4,7 +4,7 @@
     "token": "btc",
     "networks": {
       "regtest": {
-        "services": ["bitcoincore", "electrumx", "electrum"],
+        "services": ["bitcoincore", "electrs", "electrum"],
         "dockerComposePath": "./docker-compose/regtest/btc.yml",
         "configurable": [
           "bitcoincoreRpc",
@@ -14,7 +14,7 @@
         ]
       },
       "testnet": {
-        "services": ["bitcoincore", "electrumx", "electrum"],
+        "services": ["bitcoincore", "electrs", "electrum"],
         "dockerComposePath": "./docker-compose/testnet/btc.yml",
         "configurable": [
           "bitcoincoreRpc",
@@ -24,7 +24,7 @@
         ]
       },
       "mainnet": {
-        "services": ["bitcoincore", "electrumx", "electrum"],
+        "services": ["bitcoincore", "electrs", "electrum"],
         "dockerComposePath": "./docker-compose/mainnet/btc.yml",
         "configurable": [
           "bitcoincoreRpc",

--- a/docker-compose/mainnet/btc.yml
+++ b/docker-compose/mainnet/btc.yml
@@ -13,6 +13,8 @@ services:
       -zmqpubhashblock=tcp://0.0.0.0:28332
     volumes:
       - ${BLOCKCHAIN_PATH}/bitcoincode:/home/bitcoin/.bitcoin
+    environment:
+      NETWORK: ${NETWORK}
 
   electrs:
     build: ../../packages/nodechain-electrs

--- a/docker-compose/regtest/btc.yml
+++ b/docker-compose/regtest/btc.yml
@@ -18,6 +18,8 @@ services:
       -zmqpubhashblock=tcp://0.0.0.0:28332
     volumes:
       - ${BLOCKCHAIN_PATH}/bitcoincode:/home/bitcoin/.bitcoin
+    environment:
+      NETWORK: ${NETWORK}
 
   electrs:
     build: ../../packages/nodechain-electrs

--- a/docker-compose/testnet/btc.yml
+++ b/docker-compose/testnet/btc.yml
@@ -15,6 +15,8 @@ services:
       -zmqpubhashblock=tcp://0.0.0.0:28332
     volumes:
       - ${BLOCKCHAIN_PATH}/bitcoincode:/home/bitcoin/.bitcoin
+    environment:
+      NETWORK: ${NETWORK}
 
   electrs:
     build: ../../packages/nodechain-electrs

--- a/packages/nodechain-bitcoin-core/entrypoint.sh
+++ b/packages/nodechain-bitcoin-core/entrypoint.sh
@@ -19,6 +19,21 @@ fi
 
 if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
   echo
+  if [ "${NETWORK}" = "regtest" ]; then
+    WALLETDIR="$BITCOIN_DATA/regtest"
+  elif [ "${NETWORK}" = "testnet" ]; then
+    WALLETDIR="$BITCOIN_DATA/testnet3"
+  elif [ "${NETWORK}" = "mainnet" ]; then
+    WALLETDIR="$BITCOIN_DATA/mainnet"
+  fi
+  
+  WALLETFILE="${WALLETDIR}/wallet.dat"
+  mkdir -p "${WALLETDIR}"
+  chown -R bitcoin:bitcoin "${WALLETDIR}"
+  if ! [ -f "${WALLETFILE}" ]; then
+    echo "The wallet does not exists, creating it at ${WALLETDIR}..."
+    gosu bitcoin bitcoin-wallet "-wallet=" create
+  fi
   exec gosu bitcoin "$@"
 fi
 


### PR DESCRIPTION
# Description

- `availableCurrencies.json` updated and fixed
- Added a conditional to create a default wallet if there's no other wallet

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

Fixes #87 (issue)

## Dependencies (if any)

<!--List any dependencies that are required for this change.-->

## Type of change

<!--Please delete options that are not relevant.-->

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **This change requires a documentation update**

# How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. -->
<!--Provide instructions so we can reproduce the changes, if possible add screenshots, gifs or logs to facilitate the work.-->
<!--Please also list any relevant details for your test configuration.-->

```sh
~/projects/swapper-org/NodeChain/scripts$ docker logs btctestnetapi_bitcoincore_1 
/entrypoint.sh: assuming arguments for bitcoind
/entrypoint.sh: setting data directory to /home/bitcoin/.bitcoin

-------->The wallet does not exists, creating it at /home/bitcoin/.bitcoin/testnet3...
Topping up keypool...
Wallet info
===========
Name: 
Format: bdb
Descriptors: no
Encrypted: no
HD (hd seed available): yes
Keypool Size: 2000
Transactions: 0
Address Book: 0
-------->2022-02-10T17:17:43Z Bitcoin Core version v0.21.1 (release build)
2022-02-10T17:17:43Z Assuming ancestors of block 000000000000006433d1efec504c53ca332b64963c425395515b01977bd7b3b0 have valid signatures.
2022-02-10T17:17:43Z Setting nMinimumChainWork=0000000000000000000000000000000000000000000001db6ec4ac88cf2272c6
2022-02-10T17:17:43Z Using the 'sse4(1way),sse41(4way),avx2(8way)' SHA256 implementation
2022-02-10T17:17:43Z Using RdSeed as additional entropy source
2022-02-10T17:17:43Z Using RdRand as an additional entropy source
2022-02-10T17:17:43Z Default data directory /home/bitcoin/.bitcoin
2022-02-10T17:17:43Z Using data directory /home/bitcoin/.bitcoin/testnet3
2022-02-10T17:17:43Z Config file: /home/bitcoin/.bitcoin/bitcoin.conf (not found, skipping)
2022-02-10T17:17:43Z Command-line arg: datadir="/home/bitcoin/.bitcoin"
2022-02-10T17:17:43Z Command-line arg: prune="0"
2022-02-10T17:17:43Z Command-line arg: rpcallowip="0.0.0.0/0"
2022-02-10T17:17:43Z Command-line arg: rpcbind=****
2022-02-10T17:17:43Z Command-line arg: rpcpassword=****
2022-02-10T17:17:43Z Command-line arg: rpcport="8332"
2022-02-10T17:17:43Z Command-line arg: rpcuser=****
2022-02-10T17:17:43Z Command-line arg: server="1"
2022-02-10T17:17:43Z Command-line arg: testnet=""
2022-02-10T17:17:43Z Command-line arg: txindex="1"
2022-02-10T17:17:43Z Command-line arg: zmqpubhashblock="tcp://0.0.0.0:28332"
2022-02-10T17:17:43Z Using at most 125 automatic connections (1048576 file descriptors available)
2022-02-10T17:17:44Z Using 16 MiB out of 32/2 requested for signature cache, able to store 524288 elements
2022-02-10T17:17:44Z Using 16 MiB out of 32/2 requested for script execution cache, able to store 524288 elements
2022-02-10T17:17:44Z Script verification uses 11 additional threads
2022-02-10T17:17:44Z scheduler thread start
2022-02-10T17:17:44Z HTTP: creating work queue of depth 16
2022-02-10T17:17:44Z Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcauth for rpcauth auth generation.
2022-02-10T17:17:44Z HTTP: starting 4 worker threads
-------->2022-02-10T17:17:44Z Using wallet directory /home/bitcoin/.bitcoin/testnet3
-------->2022-02-10T17:17:44Z init message: Verifying wallet(s)...
2022-02-10T17:17:44Z init message: Loading banlist...
2022-02-10T17:17:44Z ERROR: DeserializeFileDB: Failed to open file /home/bitcoin/.bitcoin/testnet3/banlist.dat
2022-02-10T17:17:44Z Invalid or missing banlist.dat; recreating
2022-02-10T17:17:44Z SetNetworkActive: true
2022-02-10T17:17:44Z Using /16 prefix for IP bucketing
2022-02-10T17:17:44Z Cache configuration:
2022-02-10T17:17:44Z * Using 2.0 MiB for block index database
2022-02-10T17:17:44Z * Using 56.0 MiB for transaction index database
2022-02-10T17:17:44Z * Using 8.0 MiB for chain state database
2022-02-10T17:17:44Z * Using 384.0 MiB for in-memory UTXO set (plus up to 286.1 MiB of unused mempool space)
2022-02-10T17:17:44Z init message: Loading block index...
2022-02-10T17:17:44Z Switching active chainstate to Chainstate [ibd] @ height -1 (null)
2022-02-10T17:17:44Z Opening LevelDB in /home/bitcoin/.bitcoin/testnet3/blocks/index
2022-02-10T17:17:44Z Opened LevelDB successfully
2022-02-10T17:17:44Z Using obfuscation key for /home/bitcoin/.bitcoin/testnet3/blocks/index: 0000000000000000
2022-02-10T17:17:44Z LoadBlockIndexDB: last block file = 0
2022-02-10T17:17:44Z LoadBlockIndexDB: last block file info: CBlockFileInfo(blocks=0, size=0, heights=0...0, time=1970-01-01...1970-01-01)
2022-02-10T17:17:44Z Checking all blk files are present...
2022-02-10T17:17:44Z Initializing databases...
2022-02-10T17:17:44Z Pre-allocating up to position 0x1000000 in blk00000.dat
2022-02-10T17:17:44Z Opening LevelDB in /home/bitcoin/.bitcoin/testnet3/chainstate
2022-02-10T17:17:44Z Opened LevelDB successfully
2022-02-10T17:17:44Z Wrote new obfuscate key for /home/bitcoin/.bitcoin/testnet3/chainstate: 4891ba7816be25c2
2022-02-10T17:17:44Z Using obfuscation key for /home/bitcoin/.bitcoin/testnet3/chainstate: 4891ba7816be25c2
2022-02-10T17:17:44Z init message: Rewinding blocks...
2022-02-10T17:17:44Z  block index              17ms
2022-02-10T17:17:44Z Opening LevelDB in /home/bitcoin/.bitcoin/testnet3/indexes/txindex
2022-02-10T17:17:44Z Opened LevelDB successfully
2022-02-10T17:17:44Z Using obfuscation key for /home/bitcoin/.bitcoin/testnet3/indexes/txindex: 0000000000000000
2022-02-10T17:17:44Z txindex thread start
2022-02-10T17:17:44Z txindex is enabled
2022-02-10T17:17:44Z txindex thread exit
2022-02-10T17:17:44Z loadblk thread start
2022-02-10T17:17:44Z UpdateTip: new best=000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943 height=0 version=0x00000001 log2_work=32.000022 tx=1 date='2011-02-02T23:16:42Z' progress=0.000000 cache=0.0MiB(0txo)
2022-02-10T17:17:44Z block tree size = 1
2022-02-10T17:17:44Z nBestHeight = 0
2022-02-10T17:17:44Z Failed to open mempool file from disk. Continuing anyway.
2022-02-10T17:17:44Z loadblk thread exit
2022-02-10T17:17:44Z torcontrol thread start
2022-02-10T17:17:44Z Bound to [::]:18333
2022-02-10T17:17:44Z Bound to 0.0.0.0:18333
2022-02-10T17:17:44Z Bound to 127.0.0.1:18334
2022-02-10T17:17:44Z init message: Loading P2P addresses...
2022-02-10T17:17:44Z ERROR: DeserializeFileDB: Failed to open file /home/bitcoin/.bitcoin/testnet3/peers.dat
2022-02-10T17:17:44Z Invalid or missing peers.dat; recreating
2022-02-10T17:17:44Z ERROR: DeserializeFileDB: Failed to open file /home/bitcoin/.bitcoin/testnet3/anchors.dat
2022-02-10T17:17:44Z 0 block-relay-only anchors will be tried for connections.
2022-02-10T17:17:44Z init message: Starting network threads...
2022-02-10T17:17:44Z net thread start
2022-02-10T17:17:44Z dnsseed thread start
2022-02-10T17:17:44Z addcon thread start
2022-02-10T17:17:44Z init message: Done loading
2022-02-10T17:17:44Z Loading addresses from DNS seed testnet-seed.bluematt.me
2022-02-10T17:17:44Z opencon thread start
2022-02-10T17:17:44Z msghand thread start
2022-02-10T17:17:44Z Loading addresses from DNS seed seed.testnet.bitcoin.sprovoost.nl
2022-02-10T17:17:44Z Loading addresses from DNS seed seed.tbtc.petertodd.org
2022-02-10T17:17:44Z Loading addresses from DNS seed testnet-seed.bitcoin.jonasschnelli.ch
2022-02-10T17:17:44Z 70 addresses found from DNS seeds
2022-02-10T17:17:44Z dnsseed thread exit
2022-02-10T17:17:44Z New outbound peer connected: version: 70015, blocks=2140518, peer=0 (full-relay)
2022-02-10T17:17:45Z Synchronizing blockheaders, height: 2000 (~0.39%)
2022-02-10T17:17:46Z Synchronizing blockheaders, height: 4000 (~0.78%)
2022-02-10T17:17:46Z Synchronizing blockheaders, height: 6000 (~1.16%)
2022-02-10T17:17:46Z Synchronizing blockheaders, height: 8000 (~1.54%)
2022-02-10T17:17:46Z Synchronizing blockheaders, height: 10000 (~1.92%)
2022-02-10T17:17:47Z Synchronizing blockheaders, height: 12000 (~2.30%)
2022-02-10T17:17:47Z Synchronizing blockheaders, height: 14000 (~2.67%)
2022-02-10T17:17:47Z New outbound peer connected: version: 70016, blocks=2140518, peer=1 (full-relay)
2022-02-10T17:17:47Z Synchronizing blockheaders, height: 16000 (~3.05%)
2022-02-10T17:17:47Z Synchronizing blockheaders, height: 18000 (~3.47%)
2022-02-10T17:17:47Z Synchronizing blockheaders, height: 20000 (~3.85%)
2022-02-10T17:17:48Z Synchronizing blockheaders, height: 22000 (~4.24%)
2022-02-10T17:17:48Z Synchronizing blockheaders, height: 24000 (~4.62%)
2022-02-10T17:17:48Z Synchronizing blockheaders, height: 26000 (~4.99%)
2022-02-10T17:17:48Z Synchronizing blockheaders, height: 28000 (~5.38%)
2022-02-10T17:17:49Z Synchronizing blockheaders, height: 30000 (~5.74%)
2022-02-10T17:17:49Z New outbound peer connected: version: 70015, blocks=2140518, peer=2 (full-relay)
2022-02-10T17:17:49Z Synchronizing blockheaders, height: 32000 (~6.10%)
2022-02-10T17:17:49Z Synchronizing blockheaders, height: 34000 (~6.51%)
2022-02-10T17:17:49Z Synchronizing blockheaders, height: 36000 (~6.89%)
2022-02-10T17:17:50Z Synchronizing blockheaders, height: 38000 (~7.27%)
2022-02-10T17:17:50Z Synchronizing blockheaders, height: 40000 (~7.67%)
2022-02-10T17:17:50Z New outbound peer connected: version: 70013, blocks=2140518, peer=3 (full-relay)
2022-02-10T17:17:50Z Synchronizing blockheaders, height: 42000 (~8.04%)
2022-02-10T17:17:50Z Synchronizing blockheaders, height: 44000 (~8.40%)
2022-02-10T17:17:51Z Synchronizing blockheaders, height: 46000 (~8.76%)
2022-02-10T17:17:51Z Synchronizing blockheaders, height: 48000 (~9.15%)
2022-02-10T17:17:51Z Synchronizing blockheaders, height: 50000 (~9.55%)
2022-02-10T17:17:52Z Synchronizing blockheaders, height: 52000 (~9.91%)
2022-02-10T17:17:52Z Synchronizing blockheaders, height: 54000 (~10.27%)
2022-02-10T17:17:52Z Synchronizing blockheaders, height: 56000 (~10.65%)
2022-02-10T17:17:52Z Synchronizing blockheaders, height: 58000 (~11.01%)
2022-02-10T17:17:53Z Synchronizing blockheaders, height: 60000 (~11.36%)
2022-02-10T17:17:53Z Synchronizing blockheaders, height: 62000 (~11.72%)
2022-02-10T17:17:53Z Synchronizing blockheaders, height: 64000 (~12.08%)
2022-02-10T17:17:53Z Synchronizing blockheaders, height: 66000 (~12.44%)
2022-02-10T17:17:54Z Synchronizing blockheaders, height: 68000 (~12.81%)
```

**Test Configuration**:
* Operating system (output of `cat /etc/os-release`):
* Kernel version (output of `uname -sr`):
* Architecture (output of `uname -m`):

# Related PR or Docs PR

<!--Please add any related Pull Requests here. -->
Docs PR related # <!--(if any)-->
Other PR related # <!--(if any)-->

# Good practices to consider

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules