### PR TITLE
Extract connector from docker-compose

### DIFF
--- a/docker-compose/connector.yml
+++ b/docker-compose/connector.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  connector:
+    build: ../Connector
+    image: connector
+
+  nginx:
+    image: nginx
+    volumes:
+      - ${NGINX_CONFIG_PATH}:/etc/nginx/nginx.conf
+      - ${CERT_PATH}:/etc/nginx/certs
+    ports:
+      - ${PORT}:80
+      - ${SSL_PORT}:443
+
+networks:
+  default:
+    external:
+      name: nodechain-network

--- a/docker-compose/mainnet/bch.yml
+++ b/docker-compose/mainnet/bch.yml
@@ -22,18 +22,7 @@ services:
     build: ../../packages/nodechain-electron-cash
     image: electrum
 
-  connector:
-    build: ../../Connector
-    environment:
-      COIN: BCH
-      NETWORK: ${NETWORK}
-    image: connector
-
-  nginx:
-    image: nginx
-    volumes:
-      - ${NGINX_CONFIG_PATH}:/etc/nginx/nginx.conf
-      - ${CERT_PATH}:/etc/nginx/certs
-    ports:
-      - ${PORT}:80
-      - ${SSL_PORT}:443
+networks:
+  default:
+    external:
+      name: nodechain-network

--- a/docker-compose/mainnet/btc.yml
+++ b/docker-compose/mainnet/btc.yml
@@ -31,19 +31,7 @@ services:
     build: ../../packages/nodechain-electrum
     image: electrum
 
-  connector:
-    build: ../../Connector
-    environment:
-      COIN: BTC
-      NETWORK: ${NETWORK}
-      PORT: ${PORT}
-    image: connector
-
-  nginx:
-    image: nginx
-    volumes:
-      - ${NGINX_CONFIG_PATH}:/etc/nginx/nginx.conf
-      - ${CERT_PATH}:/etc/nginx/certs
-    ports:
-      - ${PORT}:80
-      - ${SSL_PORT}:443
+networks:
+  default:
+    external:
+      name: nodechain-network

--- a/docker-compose/mainnet/eth.yml
+++ b/docker-compose/mainnet/eth.yml
@@ -6,23 +6,7 @@ services:
     volumes:
       - ${BLOCKCHAIN_PATH}/ethereumgo:/root/.ethereum
 
-  connector:
-    build: ../../Connector
-    environment:
-      COIN: ETH
-      NETWORK: ${NETWORK}
-      PORT: ${PORT}
-    image: connector
-    depends_on:
-      - ethereumgo
-
-  nginx:
-    image: nginx
-    volumes:
-      - ${NGINX_CONFIG_PATH}:/etc/nginx/nginx.conf
-      - ${CERT_PATH}:/etc/nginx/certs
-    ports:
-      - ${PORT}:80
-      - ${SSL_PORT}:443
-    depends_on:
-      - connector
+networks:
+  default:
+    external:
+      name: nodechain-network

--- a/docker-compose/mainnet/xmr.yml
+++ b/docker-compose/mainnet/xmr.yml
@@ -8,23 +8,7 @@ services:
       - ${BLOCKCHAIN_PATH}/bitmonero:/home/monero/.bitmonero
     user: "${UID}:${GID}"
 
-  connector:
-    build: ../../Connector
-    environment:
-      COIN: XMR
-      NETWORK: ${NETWORK}
-      PORT: ${PORT}
-    image: connector
-    depends_on:
-      - monerod
-
-  nginx:
-    image: nginx
-    volumes:
-      - ${NGINX_CONFIG_PATH}:/etc/nginx/nginx.conf
-      - ${CERT_PATH}:/etc/nginx/certs
-    ports:
-      - ${PORT}:80
-      - ${SSL_PORT}:443
-    depends_on:
-      - connector
+networks:
+  default:
+    external:
+      name: nodechain-network

--- a/docker-compose/regtest/btc.yml
+++ b/docker-compose/regtest/btc.yml
@@ -41,19 +41,7 @@ services:
     environment:
       REGTEST: 1
 
-  connector:
-    build: ../../Connector
-    environment:
-      COIN: BTC
-      NETWORK: ${NETWORK}
-      PORT: ${PORT}
-    image: connector
-
-  nginx:
-    image: nginx
-    volumes:
-      - ${NGINX_CONFIG_PATH}:/etc/nginx/nginx.conf
-      - ${CERT_PATH}:/etc/nginx/certs
-    ports:
-      - ${PORT}:80
-      - ${SSL_PORT}:443
+networks:
+  default:
+    external:
+      name: nodechain-network

--- a/docker-compose/regtest/eth.yml
+++ b/docker-compose/regtest/eth.yml
@@ -6,24 +6,7 @@ services:
     volumes:
       - ${BLOCKCHAIN_PATH}/ethereumgo:/root/.ethereum
 
-  connector:
-    build: ../../Connector
-    environment:
-      COIN: ETH
-      NETWORK: ${NETWORK}
-      PORT: ${PORT}
-    image: connector
-    restart: on-failure
-    depends_on:
-      - ethereumgo
-
-  nginx:
-    image: nginx
-    volumes:
-      - ${NGINX_CONFIG_PATH}:/etc/nginx/nginx.conf
-      - ${CERT_PATH}:/etc/nginx/certs
-    ports:
-      - ${PORT}:80
-      - ${SSL_PORT}:443
-    depends_on:
-      - connector
+networks:
+  default:
+    external:
+      name: nodechain-network

--- a/docker-compose/testnet/bch.yml
+++ b/docker-compose/testnet/bch.yml
@@ -25,19 +25,7 @@ services:
     environment:
       TESTNET: 1
 
-  connector:
-    build: ../../Connector
-    environment:
-      COIN: BCH
-      NETWORK: ${NETWORK}
-      PORT: ${PORT}
-    image: connector
-
-  nginx:
-    image: nginx
-    volumes:
-      - ${NGINX_CONFIG_PATH}:/etc/nginx/nginx.conf
-      - ${CERT_PATH}:/etc/nginx/certs
-    ports:
-      - ${PORT}:80
-      - ${SSL_PORT}:443
+networks:
+  default:
+    external:
+      name: nodechain-network

--- a/docker-compose/testnet/btc.yml
+++ b/docker-compose/testnet/btc.yml
@@ -38,19 +38,7 @@ services:
     environment:
       TESTNET: 1
 
-  connector:
-    build: ../../Connector
-    environment:
-      COIN: BTC
-      NETWORK: ${NETWORK}
-      PORT: ${PORT}
-    image: connector
-
-  nginx:
-    image: nginx
-    volumes:
-      - ${NGINX_CONFIG_PATH}:/etc/nginx/nginx.conf
-      - ${CERT_PATH}:/etc/nginx/certs
-    ports:
-      - ${PORT}:80
-      - ${SSL_PORT}:443
+networks:
+  default:
+    external:
+      name: nodechain-network

--- a/docker-compose/testnet/eth.yml
+++ b/docker-compose/testnet/eth.yml
@@ -6,23 +6,7 @@ services:
     volumes:
       - ${BLOCKCHAIN_PATH}/ethereumgo:/root/.ethereum
 
-  connector:
-    build: ../../Connector
-    environment:
-      COIN: ETH
-      NETWORK: ${NETWORK}
-      PORT: ${PORT}
-    image: connector
-    depends_on:
-      - ethereumgo
-
-  nginx:
-    image: nginx
-    volumes:
-      - ${NGINX_CONFIG_PATH}:/etc/nginx/nginx.conf
-      - ${CERT_PATH}:/etc/nginx/certs
-    ports:
-      - ${PORT}:80
-      - ${SSL_PORT}:443
-    depends_on:
-      - connector
+networks:
+  default:
+    external:
+      name: nodechain-network

--- a/docker-compose/testnet/xmr.yml
+++ b/docker-compose/testnet/xmr.yml
@@ -8,23 +8,7 @@ services:
       - ${BLOCKCHAIN_PATH}/bitmonero:/home/monero/.bitmonero
     user: "${UID}:${GID}"
 
-  connector:
-    build: ../../Connector
-    environment:
-      COIN: XMR
-      NETWORK: ${NETWORK}
-      PORT: ${PORT}
-    image: connector
-    depends_on:
-      - monerod
-
-  nginx:
-    image: nginx
-    volumes:
-      - ${NGINX_CONFIG_PATH}:/etc/nginx/nginx.conf
-      - ${CERT_PATH}:/etc/nginx/certs
-    ports:
-      - ${PORT}:80
-      - ${SSL_PORT}:443
-    depends_on:
-      - connector
+networks:
+  default:
+    external:
+      name: nodechain-network


### PR DESCRIPTION
# Description

Connector is extracted from docker-composes and it is now in his own file.

Take take note that:
- admin endpoints are exposed. This CAN'T be fixed directly in nginx files as localhost identification bypassed if it is ran by docker. In a future it should be considered to implement an Authorization header (https://developer.mozilla.org/es/docs/Web/HTTP/Headers/Authorization) in the connector. (I am going to add a new PR).
- In a future, when the startup script would be modified, it must create a new network with `docker network create nodechain-network`

Fixes #95

## Type of change

<!--Please delete options that are not relevant.-->

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **This change requires a documentation update**

# Good practices to consider

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules