### PR TITLE
Update getFeePerByte from kb to byte

### DIFF
--- a/Connector/bch/apirpc.py
+++ b/Connector/bch/apirpc.py
@@ -325,7 +325,7 @@ def getFeePerByte(id, params, config):
         logger.printError("Response without feerate field. No fee rate found")
         raise error.RpcInternalServerError("Response without feerate field. No fee rate found")
 
-    response = {"feePerByte": utils.convertToSatoshi(feePerByte["feerate"])}
+    response = {"feePerByte": utils.convertKbToBytes(utils.convertToSatoshi(feePerByte["feerate"]))}
 
     err = httputils.validateJSONSchema(response, responseSchema)
     if err is not None:

--- a/Connector/bch/utils.py
+++ b/Connector/bch/utils.py
@@ -7,6 +7,10 @@ def convertToSatoshi(strAmount):
     return str(int(Decimal(strAmount) * 100000000))
 
 
+def convertKbToBytes(strAmount):
+    return str(int(Decimal(strAmount) / 1000))
+
+
 def getMethodSchemas(name):
     return getRequestMethodSchema(name), getResponseMethodSchema(name)
 

--- a/Connector/btc/apirpc.py
+++ b/Connector/btc/apirpc.py
@@ -300,7 +300,7 @@ def getFeePerByte(id, params, config):
         logger.printError("Response without feerate field. No fee rate found")
         raise error.RpcInternalServerError("Response without feerate field. No fee rate found")
 
-    response = {"feePerByte": utils.convertToSatoshi(feePerByte["feerate"])}
+    response = {"feePerByte": utils.convertKbToBytes(utils.convertToSatoshi(feePerByte["feerate"]))}
 
     err = httputils.validateJSONSchema(response, responseSchema)
     if err is not None:

--- a/Connector/btc/utils.py
+++ b/Connector/btc/utils.py
@@ -13,6 +13,10 @@ def convertToSatoshi(strAmount):
     return str(int(Decimal(strAmount) * 100000000))
 
 
+def convertKbToBytes(strAmount):
+    return str(int(Decimal(strAmount) / 1000))
+
+
 def getMethodSchemas(name):
     return getRequestMethodSchema(name), getResponseMethodSchema(name)
 

--- a/Connector/tests/btc/test_btc.py
+++ b/Connector/tests/btc/test_btc.py
@@ -202,7 +202,7 @@ def testGetFeePerByte():
         CONFIRMATIONS: confirmations
     })
 
-    assert str(expected[FEE_RATE]) == str(float((Decimal(got[FEE_PER_BYTE]) / 100000000)))
+    assert str(expected[FEE_RATE]) == str(float((Decimal(got[FEE_PER_BYTE]) / 100000000 * 1000)))
 
 
 def testBroadcastTransaction():


### PR DESCRIPTION
# Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
After researching, we conclude that `EstimateSmartFee` returns the amount in KB. Now the amount is returned in sat/byte

Fixes #75  (issue)

## Dependencies (if any)

<!--List any dependencies that are required for this change.-->

## Type of change

<!--Please delete options that are not relevant.-->

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **This change requires a documentation update**

# How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. -->
<!--Provide instructions so we can reproduce the changes, if possible add screenshots, gifs or logs to facilitate the work.-->
<!--Please also list any relevant details for your test configuration.-->

`{'feePerByte': '1'}`

**Test Configuration**:
* Operating system (output of `cat /etc/os-release`):
* Kernel version (output of `uname -sr`):
* Architecture (output of `uname -m`):

# Related PR or Docs PR

<!--Please add any related Pull Requests here. -->
Docs PR related # <!--(if any)-->
Other PR related # <!--(if any)-->

# Good practices to consider

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules