### PR TITLE
BTC GetTransaction refactor

### DIFF
--- a/Connector/btc/apirpc.py
+++ b/Connector/btc/apirpc.py
@@ -242,7 +242,7 @@ def getBlockByHash(id, params, config):
         method=GET_BLOCK_METHOD,
         params=[
             params["blockHash"],
-            VERBOSITY_MORE_MODE
+            params["verbosity"] if "verbosity" in params else VERBOSITY_MORE_MODE
         ]
     )
 
@@ -274,7 +274,10 @@ def getBlockByNumber(id, params, config):
 
     return getBlockByHash(
         id=id,
-        params={"blockHash": blockHash},
+        params={
+            "blockHash": blockHash,
+            "verbosity": params["verbosity"] if "verbosity" in params else VERBOSITY_MORE_MODE
+        },
         config=config
     )
 
@@ -370,7 +373,10 @@ def getTransactionHex(id, params, config):
         endpoint=config.bitcoincoreRpcEndpoint,
         id=id,
         method=GET_RAW_TRANSACTION_METHOD,
-        params=[params["txHash"]]
+        params=[
+            params["txHash"],
+            False if "verbose" not in params else params["verbose"]
+        ]
     )
 
     response = {"rawTransaction": rawTransaction}
@@ -385,6 +391,7 @@ def getTransactionHex(id, params, config):
 @rpcmethod.rpcMethod(coin=COIN_SYMBOL)
 @httpmethod.postHttpMethod(coin=COIN_SYMBOL)
 def getTransaction(id, params, config):
+
     logger.printInfo(f"Executing RPC method getTransaction with id {id} and params {params}")
 
     requestSchema, responseSchema = utils.getMethodSchemas(GET_TRANSACTION)
@@ -394,32 +401,33 @@ def getTransaction(id, params, config):
         raise error.RpcBadRequestError(id=id, message=err.message)
 
     try:
-        transaction = RPCConnector.request(
-            endpoint=config.bitcoincoreRpcEndpoint,
+        transaction = getTransactionHex(
             id=id,
-            method=GET_RAW_TRANSACTION_METHOD,
-            params=[
-                params["txHash"],
-                True
-            ]
+            params={
+                "txHash": params["txHash"],
+                "verbose": True
+            },
+            config=config
         )
 
         # Check if transaction is confirmed, and obtain block number
-        if "blockhash" in transaction:
-            transactionBlock = RPCConnector.request(
-                endpoint=config.bitcoincoreRpcEndpoint,
+        if "blockhash" in transaction["rawTransaction"]:
+            transactionBlock = getBlockByHash(
                 id=id,
-                method=GET_BLOCK,
-                params=[transaction["blockhash"], 1]
+                params={
+                    "blockHash": transaction["rawTransaction"]["blockhash"],
+                    "verbosity": VERBOSITY_DEFAULT_MODE
+                },
+                config=config
             )
             blockNumber = transactionBlock["height"]
         else:
             blockNumber = None
 
-        transactionDetails = utils.decodeTransactionDetails(transaction, config.bitcoincoreRpcEndpoint)
+        transactionDetails = utils.decodeTransactionDetails(transaction["rawTransaction"], id, config)
 
         # Converting all transaction details to str
-        transactionDetails["fee"] = str(transactionDetails["fee"])
+
         for input in transactionDetails["inputs"]:
             input["amount"] = str(input["amount"])
         for output in transactionDetails["outputs"]:
@@ -427,10 +435,10 @@ def getTransaction(id, params, config):
 
         response = {
             "transaction": {
-                "txId": transaction["txid"],
-                "txHash": transaction["hash"],
+                "txId": transaction["rawTransaction"]["txid"],
+                "txHash": transaction["rawTransaction"]["hash"],
                 "blockNumber": str(blockNumber) if blockNumber is not None else blockNumber,
-                "fee": transactionDetails["fee"],
+                "fee": str(transactionDetails["fee"]),
                 "inputs": transactionDetails["inputs"],
                 "outputs": transactionDetails["outputs"],
                 "data": transaction

--- a/Connector/btc/apirpc.py
+++ b/Connector/btc/apirpc.py
@@ -441,7 +441,7 @@ def getTransaction(id, params, config):
                 "fee": str(transactionDetails["fee"]),
                 "inputs": transactionDetails["inputs"],
                 "outputs": transactionDetails["outputs"],
-                "data": transaction
+                "data": transaction["rawTransaction"]
             }
         }
 

--- a/Connector/btc/rpcschemas/getblockbyhash_request.json
+++ b/Connector/btc/rpcschemas/getblockbyhash_request.json
@@ -6,6 +6,14 @@
     "properties": {
         "blockHash" : {
             "type": "string"
+        },
+        "verbosity": {
+            "type": "integer",
+            "enum": [
+                0,
+                1,
+                2
+            ]
         }
     },
     "required": [

--- a/Connector/btc/rpcschemas/getblockbyhash_response.json
+++ b/Connector/btc/rpcschemas/getblockbyhash_response.json
@@ -2,7 +2,10 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "title": "",
     "description": "",
-    "type": "object",
+    "type": [
+        "object",
+        "string"
+    ],
     "properties": {
         "hash": {
             "type": "string"
@@ -55,7 +58,10 @@
         "tx": {
             "type": "array",
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "string"
+                ],
                 "properties": {
                     "txid": {
                         "type": "string"

--- a/Connector/btc/rpcschemas/getblockbynumber_request.json
+++ b/Connector/btc/rpcschemas/getblockbynumber_request.json
@@ -6,6 +6,14 @@
     "properties": {
         "blockNumber" : {
             "type": "integer"
+        },
+        "verbosity": {
+            "type": "integer",
+            "enum": [
+                0,
+                1,
+                2
+            ]
         }
     },
     "required": [

--- a/Connector/btc/rpcschemas/getblockbynumber_response.json
+++ b/Connector/btc/rpcschemas/getblockbynumber_response.json
@@ -2,7 +2,10 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "title": "",
     "description": "",
-    "type": "object",
+    "type": [
+        "object",
+        "string"
+    ],
     "properties": {
         "hash": {
             "type": "string"
@@ -55,7 +58,10 @@
         "tx": {
             "type": "array",
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "string"
+                ],
                 "properties": {
                     "txid": {
                         "type": "string"

--- a/Connector/btc/rpcschemas/gettransaction_response.json
+++ b/Connector/btc/rpcschemas/gettransaction_response.json
@@ -10,6 +10,9 @@
                 "null"
             ],
             "properties": {
+                "txId": {
+                    "type": "string"
+                },
                 "txHash": {
                     "type": "string"
                 },

--- a/Connector/btc/rpcschemas/gettransactionhex_request.json
+++ b/Connector/btc/rpcschemas/gettransactionhex_request.json
@@ -6,6 +6,9 @@
     "properties": {
         "txHash" : {
             "type" : "string"
+        },
+        "verbose": {
+            "type": "boolean"
         }
     },
     "required": [

--- a/Connector/btc/rpcschemas/gettransactionhex_response.json
+++ b/Connector/btc/rpcschemas/gettransactionhex_response.json
@@ -4,8 +4,123 @@
     "description": "",
     "type": "object",
     "properties": {
-        "rawTransaction" : {
-            "type" : "string"
+        "rawTransaction": {
+            "type": [
+                "string",
+                "object"
+            ],
+            "properties": {
+                "hex": {
+                    "type": "string"
+                },
+                "txid": {
+                    "type": "string"
+                },
+                "hash": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "vSize": {
+                    "type": "integer"
+                },
+                "weight": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "integer"
+                },
+                "lockTime": {
+                    "type": "integer"
+                },
+                "blockHash": {
+                    "type": "string"
+                },
+                "confirmations": {
+                    "type": "integer"
+                },
+                "blockTime": {
+                    "type": "integer"
+                },
+                "time": {
+                    "type": "integer"
+                },
+                "vin": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "coinbase": {
+                                "type": "string"
+                            },
+                            "sequence": {
+                                "type": "integer"
+                            },
+                            "txid": {
+                                "type": "string"
+                            },
+                            "vout": {
+                                "type": "integer"
+                            },
+                            "scriptSig": {
+                                "type": "object",
+                                "properties": {
+                                    "asm": {
+                                        "type": "string"
+                                    },
+                                    "hex": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "txinwitness": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "vout": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "value": {
+                                "type": "number"
+                            },
+                            "n": {
+                                "type": "integer"
+                            },
+                            "scriptPubKey": {
+                                "type": "object",
+                                "properties": {
+                                    "asm": {
+                                        "type": "string"
+                                    },
+                                    "hex": {
+                                        "type": "string"
+                                    },
+                                    "reqSigs": {
+                                        "type": "integer"
+                                    },
+                                    "type": {
+                                        "type": "string"
+                                    },
+                                    "addresses": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "required": [

--- a/Connector/btc/utils.py
+++ b/Connector/btc/utils.py
@@ -113,7 +113,7 @@ def decodeTransactionDetails(txDecoded, id, config):
             config=config
         )
 
-        for txOutput in transaction["vout"]:
+        for txOutput in transaction["rawTransaction"]["vout"]:
             if txOutput["n"] == txInput["vout"] and "addresses" in txOutput["scriptPubKey"] and len(
                     txOutput["scriptPubKey"]["addresses"]) == 1:
                 inputs.append(

--- a/Connector/tests/btc/test_btc.py
+++ b/Connector/tests/btc/test_btc.py
@@ -505,7 +505,7 @@ def testGetTransaction():
 
     got = postHttpMethods[COIN_SYMBOL]["getTransaction"]({"txHash": txHash}, config)
 
-    txDetails = decodeTransactionDetails(expectedTransaction, config.bitcoincoreRpcEndpoint)
+    txDetails = decodeTransactionDetails(expectedTransaction, 0, config)
 
     for input in txDetails["inputs"]:
         input["amount"] = str(input["amount"])
@@ -550,7 +550,7 @@ def testGetTransactions():
                 found = True
                 expectedTransaction = makeBitcoinCoreRequest(GET_RAW_TRANSACTION_METHOD, [txHash, True])
                 expectedBlock = makeBitcoinCoreRequest(GET_BLOCK, [expectedTransaction["blockhash"], 1])
-                txDetails = decodeTransactionDetails(expectedTransaction, config.bitcoincoreRpcEndpoint)
+                txDetails = decodeTransactionDetails(expectedTransaction, 0, config)
 
                 for input in txDetails["inputs"]:
                     input["amount"] = str(input["amount"])


### PR DESCRIPTION
# Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

GetTransaction method reuses BTC apirpc methods. GetBlockByHash, GetBlockByNumber and GetTransactionHex can receive a verbose parameter to be compatible with GetTransaction and not duplicate code with RPC queries

Fixes #88

## Dependencies (if any)

<!--List any dependencies that are required for this change.-->

## Type of change

<!--Please delete options that are not relevant.-->

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **This change requires a documentation update**

# How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. -->
<!--Provide instructions so we can reproduce the changes, if possible add screenshots, gifs or logs to facilitate the work.-->
<!--Please also list any relevant details for your test configuration.-->

- GetBlockByNumber with less grade of verbosity
    Request
    ```sh
    curl --location --request POST 'http://localhost:80/btc/regtest/rpc' \
    --header 'Content-Type: application/json' \
    --data-raw '{
        "id": 1609070896412,
        "method": "getBlockByNumber",
        "params": {
            "blockNumber": 1222,
            "verbosity": 0
        },
        "jsonrpc": "2.0"
    }'
    ```
   Response
   ```js
    {
        "id": 1609070896412,
        "jsonrpc": "2.0",
        "result": "00000020b9e80deaeae852e4da5e901c6f6c5369d1fe765421741a8485c559e6c93dfd773afeba43b1288dd780b4da0ca4fb389949a8fa5feb7197f27b41edadb27ef3a853fe2462ffff7f200000000002020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0502c6040101ffffffff02b3082a01000000001600142c3ccc1e1a34c798ce3d1c10ea90d008750a058f0000000000000000266a24aa21a9edfba8f538bb6fd739905711a549e9db5ab8a3d83d7d20f353f857f830e800ca69012000000000000000000000000000000000000000000000000000000000000000000000000002000000000101013820196090aae90d5b7e8916dff1df013c8f907adfcbe5b509162454cb2fbf0000000000fdffffff022701000000000000160014fa5b318b682928a5d7d531326c299909ef6687d2e013a804000000001600149560c4b866342461258b83362135ec623f838de502473044022067df87ba791554133c7e30a272636138beedcf3a82ae7f062b261c9f7b4462e0022077c43104e901729f035082ebcfb47fe2483ae8289a0f18f656da4b4fda979a43012103b27695cfbe671b7495a35d0ab06f145a4caa774222bd8bbaf28829aabd2f5e1400000000"
    }
   ```
- GetBlockByNumber with medium level of verbosity

    Request
    ```sh
    curl --location --request POST 'http://localhost:80/btc/regtest/rpc' \
    --header 'Content-Type: application/json' \
    --data-raw '{
        "id": 1609070896412,
        "method": "getBlockByNumber",
        "params": {
            "blockNumber": 1222,
            "verbosity": 1
        },
        "jsonrpc": "2.0"
    }'
    ```

    Response
    ```js
    {
        "id": 1609070896412,
        "jsonrpc": "2.0",
        "result": {
            "hash": "4a9ae5ab91aa69c7c92c960bb689ff038549767bcd9e782bee11eeaee544162f",
            "confirmations": 316,
            "strippedsize": 328,
            "size": 473,
            "weight": 1457,
            "height": 1222,
            "version": 536870912,
            "versionHex": "20000000",
            "merkleroot": "a8f37eb2aded417bf29771eb5ffaa8499938fba40cdab480d78d28b143bafe3a",
            "tx": [
                "8bf047dfc18aabaf79569bc6a22ed7d391d32aed8c5b1ad347cffdb89ce91545",
                "dd8d396fcaa88f04e131bf90c82363062b05cfc18c91238c24ae03fbd9a31cff"
            ],
            "time": 1646591571,
            "mediantime": 1646591570,
            "nonce": 0,
            "bits": "207fffff",
            "difficulty": 4.656542373906925e-10,
            "chainwork": "000000000000000000000000000000000000000000000000000000000000098e",
            "nTx": 2,
            "previousblockhash": "77fd3dc9e659c585841a74215476fed169536c6f1c905edae452e8eaea0de8b9",
            "nextblockhash": "2d17efcb49b81c4956dcd6e6ed1f1623ee822f349556150945f06aae9434e8d4"
        }
    }
    ```


- GetBlockByNumber with hight grade of verbosity (**Default**)
  
    Request
    ```sh
    curl --location --request POST 'http://localhost:80/btc/regtest/rpc' \
    --header 'Content-Type: application/json' \
    --data-raw '{
        "id": 1609070896412,
        "method": "getBlockByNumber",
        "params": {
            "blockNumber": 1222
        },
        "jsonrpc": "2.0"
    }'
    ```
    
    Response
    ```js
    {
        "id": 1609070896412,
        "jsonrpc": "2.0",
        "result": {
            "hash": "4a9ae5ab91aa69c7c92c960bb689ff038549767bcd9e782bee11eeaee544162f",
            "confirmations": 316,
            "strippedsize": 328,
            "size": 473,
            "weight": 1457,
            "height": 1222,
            "version": 536870912,
            "versionHex": "20000000",
            "merkleroot": "a8f37eb2aded417bf29771eb5ffaa8499938fba40cdab480d78d28b143bafe3a",
            "tx": [
                {
                    "txid": "8bf047dfc18aabaf79569bc6a22ed7d391d32aed8c5b1ad347cffdb89ce91545",
                    "hash": "d0a6bf71fe120a05379e7d41068dd22022831fcaedc3333bcf9302e236425474",
                    "version": 2,
                    "size": 170,
                    "vsize": 143,
                    "weight": 572,
                    "locktime": 0,
                    "vin": [
                        {
                            "coinbase": "02c6040101",
                            "txinwitness": [
                                "0000000000000000000000000000000000000000000000000000000000000000"
                            ],
                            "sequence": 4294967295
                        }
                    ],
                    "vout": [
                        {
                            "value": 0.19531955,
                            "n": 0,
                            "scriptPubKey": {
                                "asm": "0 2c3ccc1e1a34c798ce3d1c10ea90d008750a058f",
                                "hex": "00142c3ccc1e1a34c798ce3d1c10ea90d008750a058f",
                                "reqSigs": 1,
                                "type": "witness_v0_keyhash",
                                "addresses": [
                                    "bcrt1q9s7vc8s6xnre3n3arsgw4yxspp6s5pv03zzn4n"
                                ]
                            }
                        },
                        {
                            "value": 0.0,
                            "n": 1,
                            "scriptPubKey": {
                                "asm": "OP_RETURN aa21a9edfba8f538bb6fd739905711a549e9db5ab8a3d83d7d20f353f857f830e800ca69",
                                "hex": "6a24aa21a9edfba8f538bb6fd739905711a549e9db5ab8a3d83d7d20f353f857f830e800ca69",
                                "type": "nulldata"
                            }
                        }
                    ],
                    "hex": "020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0502c6040101ffffffff02b3082a01000000001600142c3ccc1e1a34c798ce3d1c10ea90d008750a058f0000000000000000266a24aa21a9edfba8f538bb6fd739905711a549e9db5ab8a3d83d7d20f353f857f830e800ca690120000000000000000000000000000000000000000000000000000000000000000000000000"
                },
                {
                    "txid": "dd8d396fcaa88f04e131bf90c82363062b05cfc18c91238c24ae03fbd9a31cff",
                    "hash": "eb654ea62835954c551bdd9949dd4f12723b7f8b932b2b7ad59ea3dc372ebc9c",
                    "version": 2,
                    "size": 222,
                    "vsize": 141,
                    "weight": 561,
                    "locktime": 0,
                    "vin": [
                        {
                            "txid": "bf2fcb54241609b5e5cbdf7a908f3c01dff1df16897e5b0de9aa906019203801",
                            "vout": 0,
                            "scriptSig": {
                                "asm": "",
                                "hex": ""
                            },
                            "txinwitness": [
                                "3044022067df87ba791554133c7e30a272636138beedcf3a82ae7f062b261c9f7b4462e0022077c43104e901729f035082ebcfb47fe2483ae8289a0f18f656da4b4fda979a4301",
                                "03b27695cfbe671b7495a35d0ab06f145a4caa774222bd8bbaf28829aabd2f5e14"
                            ],
                            "sequence": 4294967293
                        }
                    ],
                    "vout": [
                        {
                            "value": 2.95e-06,
                            "n": 0,
                            "scriptPubKey": {
                                "asm": "0 fa5b318b682928a5d7d531326c299909ef6687d2",
                                "hex": "0014fa5b318b682928a5d7d531326c299909ef6687d2",
                                "reqSigs": 1,
                                "type": "witness_v0_keyhash",
                                "addresses": [
                                    "bcrt1qlfdnrzmg9y52t474xyexc2vep8hkdp7jg02mj0"
                                ]
                            }
                        },
                        {
                            "value": 0.78124,
                            "n": 1,
                            "scriptPubKey": {
                                "asm": "0 9560c4b866342461258b83362135ec623f838de5",
                                "hex": "00149560c4b866342461258b83362135ec623f838de5",
                                "reqSigs": 1,
                                "type": "witness_v0_keyhash",
                                "addresses": [
                                    "bcrt1qj4svfwrxxsjxzfvtsvmzzd0vvglc8r09q0csrg"
                                ]
                            }
                        }
                    ],
                    "hex": "02000000000101013820196090aae90d5b7e8916dff1df013c8f907adfcbe5b509162454cb2fbf0000000000fdffffff022701000000000000160014fa5b318b682928a5d7d531326c299909ef6687d2e013a804000000001600149560c4b866342461258b83362135ec623f838de502473044022067df87ba791554133c7e30a272636138beedcf3a82ae7f062b261c9f7b4462e0022077c43104e901729f035082ebcfb47fe2483ae8289a0f18f656da4b4fda979a43012103b27695cfbe671b7495a35d0ab06f145a4caa774222bd8bbaf28829aabd2f5e1400000000"
                }
            ],
            "time": 1646591571,
            "mediantime": 1646591570,
            "nonce": 0,
            "bits": "207fffff",
            "difficulty": 4.656542373906925e-10,
            "chainwork": "000000000000000000000000000000000000000000000000000000000000098e",
            "nTx": 2,
            "previousblockhash": "77fd3dc9e659c585841a74215476fed169536c6f1c905edae452e8eaea0de8b9",
            "nextblockhash": "2d17efcb49b81c4956dcd6e6ed1f1623ee822f349556150945f06aae9434e8d4"
        }
    }
    ```

- GetTransactionHex with verbosity mode (Default)

    Request
    ```sh
    curl --location --request POST 'http://localhost:80/btc/regtest/rpc' \
    --header 'Content-Type: application/json' \
    --data-raw '{
        "id": 1609070896412,
        "method": "getTransactionHex",
        "params": {
            "txHash": "06a839ad325562a2785367ff270ae2d2c30576ffdea56c99c3218edfb791c941",
            "verbose": true
        },
        "jsonrpc": "2.0"
    }'
    ```

    Response
    ```js
    {
        "id": 1609070896412,
        "jsonrpc": "2.0",
        "result": {
            "rawTransaction": {
                "txid": "06a839ad325562a2785367ff270ae2d2c30576ffdea56c99c3218edfb791c941",
                "hash": "6b89dfe1402c711e7ecb54973c9c3d6d28fee9321976607e629d52e5b102f7fc",
                "version": 2,
                "size": 222,
                "vsize": 141,
                "weight": 561,
                "locktime": 0,
                "vin": [
                    {
                        "txid": "7e1879cc8f7f6ff6571be46ce1c1b2ba3fcdfdaa32dd0de50d0add86fd840904",
                        "vout": 0,
                        "scriptSig": {
                            "asm": "",
                            "hex": ""
                        },
                        "txinwitness": [
                            "304402201c97da21c54d752567d828838b887e2072fe3d3a1652284d02dc35e634b534e4022009a114945c80bf3b1b4fe1b70e80a23da717d202e2bb1a0cc6ec050c39adb5ba01",
                            "03b27695cfbe671b7495a35d0ab06f145a4caa774222bd8bbaf28829aabd2f5e14"
                        ],
                        "sequence": 4294967293
                    }
                ],
                "vout": [
                    {
                        "value": 2.95e-06,
                        "n": 0,
                        "scriptPubKey": {
                            "asm": "0 fa5b318b682928a5d7d531326c299909ef6687d2",
                            "hex": "0014fa5b318b682928a5d7d531326c299909ef6687d2",
                            "reqSigs": 1,
                            "type": "witness_v0_keyhash",
                            "addresses": [
                                "bcrt1qlfdnrzmg9y52t474xyexc2vep8hkdp7jg02mj0"
                            ]
                        }
                    },
                    {
                        "value": 0.78124,
                        "n": 1,
                        "scriptPubKey": {
                            "asm": "0 9560c4b866342461258b83362135ec623f838de5",
                            "hex": "00149560c4b866342461258b83362135ec623f838de5",
                            "reqSigs": 1,
                            "type": "witness_v0_keyhash",
                            "addresses": [
                                "bcrt1qj4svfwrxxsjxzfvtsvmzzd0vvglc8r09q0csrg"
                            ]
                        }
                    }
                ],
                "hex": "02000000000101040984fd86dd0a0de50ddd32aafdcd3fbab2c1e16ce41b57f66f7f8fcc79187e0000000000fdffffff022701000000000000160014fa5b318b682928a5d7d531326c299909ef6687d2e013a804000000001600149560c4b866342461258b83362135ec623f838de50247304402201c97da21c54d752567d828838b887e2072fe3d3a1652284d02dc35e634b534e4022009a114945c80bf3b1b4fe1b70e80a23da717d202e2bb1a0cc6ec050c39adb5ba012103b27695cfbe671b7495a35d0ab06f145a4caa774222bd8bbaf28829aabd2f5e1400000000",
                "blockhash": "2d17efcb49b81c4956dcd6e6ed1f1623ee822f349556150945f06aae9434e8d4",
                "confirmations": 315,
                "time": 1646591571,
                "blocktime": 1646591571
            }
        }
    }
    ```
- GetTransactionHex with verbosity disable

    Request
    ```sh
    curl --location --request POST 'http://localhost:80/btc/regtest/rpc' \
    --header 'Content-Type: application/json' \
    --data-raw '{
        "id": 1609070896412,
        "method": "getTransactionHex",
        "params": {
            "txHash": "06a839ad325562a2785367ff270ae2d2c30576ffdea56c99c3218edfb791c941",
            "verbose": false
        },
        "jsonrpc": "2.0"
    }'
    ```

    Response
    ```js
    {
        "id": 1609070896412,
        "jsonrpc": "2.0",
        "result": {
            "rawTransaction": "02000000000101040984fd86dd0a0de50ddd32aafdcd3fbab2c1e16ce41b57f66f7f8fcc79187e0000000000fdffffff022701000000000000160014fa5b318b682928a5d7d531326c299909ef6687d2e013a804000000001600149560c4b866342461258b83362135ec623f838de50247304402201c97da21c54d752567d828838b887e2072fe3d3a1652284d02dc35e634b534e4022009a114945c80bf3b1b4fe1b70e80a23da717d202e2bb1a0cc6ec050c39adb5ba012103b27695cfbe671b7495a35d0ab06f145a4caa774222bd8bbaf28829aabd2f5e1400000000"
        }
    }
    ```

**Test Configuration**:
* Operating system (output of `sw_vers`): macOS 12.0.1
* Kernel version (output of `uname -sr`): Darwin 21.1.0
* Architecture (output of `uname -m`): x86_64

# Related PR or Docs PR

<!--Please add any related Pull Requests here. -->
Docs PR related # <!--(if any)-->
Other PR related # <!--(if any)-->

# Good practices to consider

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules