### PR TITLE
BTC Testnet Bug fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - run:
           name: BitcoinCore set up
           command: |
-            docker exec -it btc_regtest_api-bitcoincore-1 bash -c "rm -rf /home/bitcoin/.bitcoin/regtest/wallets/*"
+            docker exec -it btc_regtest_api-bitcoincore-regtest-1 bash -c "rm -rf /home/bitcoin/.bitcoin/regtest/wallets/*"
       - run:
           name: Run BTC tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - run:
           name: BitcoinCore set up
           command: |
-            docker exec -it btc_regtest_api-bitcoincore-regtest-1 bash -c "rm -rf /home/bitcoin/.bitcoin/regtest/wallets/*"
+            docker exec -it btc_regtest_api-bitcoincore-1 bash -c "rm -rf /home/bitcoin/.bitcoin/regtest/wallets/*"
       - run:
           name: Run BTC tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,11 +92,11 @@ jobs:
           command: |
             sleep 5 && nc -vz localhost 8332
             sleep 5 && nc -vz localhost 28332
-            #sleep 5 && nc -vz localhost 3000
+            #sleep 5 && nc -vz localhost 30000
       - run:
           name: BitcoinCore set up
           command: |
-            docker exec -it btc_regtest_api-bitcoincore-1 bash -c "rm -rf /home/bitcoin/.bitcoin/regtest/wallets/*"
+            docker exec -it btc_regtest_api-bitcoincore-regtest-1 bash -c "rm -rf /home/bitcoin/.bitcoin/regtest/wallets/*"
       - run:
           name: Run BTC tests
           command: |

--- a/Connector/tests/docker-compose/btc.yml
+++ b/Connector/tests/docker-compose/btc.yml
@@ -1,6 +1,6 @@
 version: "3"
 services:
-  bitcoincore:
+  bitcoincore-regtest:
     build: ../../../packages/nodechain-bitcoin-core
     image: bitcoincore
     command: -rpcuser=swapper
@@ -22,7 +22,7 @@ services:
       - 8332:8332
       - 28332:28332
 
-  electrs:
+  electrs-regtest:
     build: ../../../packages/nodechain-electrs
     image: electrs
     command: -v --timestamp
@@ -30,13 +30,13 @@ services:
       - bitcoincore
     environment:
       REGTEST: 1
-      DAEMON_RPC_URL: bitcoincore:8332
+      DAEMON_RPC_URL: bitcoincore-regtest:8332
       ELECTRUM_RPC_URL: 0.0.0.0:60401
     volumes:
       - ${BLOCKCHAIN_PATH}/electrs:/build/.electrs
       - ${BLOCKCHAIN_PATH}/bitcoincode:/home/bitcoin/.bitcoin
 
-  electrum:
+  electrum-regtest:
     build: ../../../packages/nodechain-electrum-regtest
     image: electrum
     environment:

--- a/docker-compose/testnet/btc.yml
+++ b/docker-compose/testnet/btc.yml
@@ -35,7 +35,7 @@ services:
     build: ../../packages/nodechain-electrum
     image: electrum
     depends_on:
-      - electrs-testnest
+      - electrs-testnet
     environment:
       TESTNET: 1
       NETWORK: ${NETWORK}


### PR DESCRIPTION
# Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

BTC Testnet Bug fix at deployment

Fixes #127

## Dependencies (if any)

<!--List any dependencies that are required for this change.-->

## Type of change

<!--Please delete options that are not relevant.-->

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **This change requires a documentation update**

# How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. -->
<!--Provide instructions so we can reproduce the changes, if possible add screenshots, gifs or logs to facilitate the work.-->
<!--Please also list any relevant details for your test configuration.-->

- BTC Testnet deployment successfully

```sh
---------------------------------------------------
  _  _          _        ___  _                   
 | \| | ___  __| | ___  / __|| |_   __ _ (_) _ _  
 | .` |/ _ \/ _` |/ -_)| (__ | ' \ / _` || || ' \ 
 |_|\_|\___/\__,_|\___| \___||_||_|\__,_||_||_||_|
---------------------------------------------------
===================================================
		CONNECTOR CONFIG
===================================================
Port to start: 80
Port to start (SSL): 443
Starting network nodechain-network.
nodechain-network is already started
Starting connector and reverse proxy... This might take a while.
Connector has been started
Starting btctestnetapi node... This might take a while.
btctestnetapi node started
Do you want to configure your API  [y/N]: n
btc testnet has registered succesfully in the connector
```

```sh
docker ps

CONTAINER ID   IMAGE         COMMAND                  CREATED          STATUS          PORTS                                                                         NAMES
d9623e3e3279   electrum      "/usr/src/app/entryp…"   39 seconds ago   Up 38 seconds   30000/tcp                                                                     btctestnetapi_electrum-testnet_1
22f4aae2617d   electrs       "/build/entrypoint.s…"   40 seconds ago   Up 39 seconds   50001/tcp, 60001/tcp, 60401/tcp                                               btctestnetapi_electrs-testnet_1
ea0e4a165c5a   bitcoincore   "/entrypoint.sh -rpc…"   41 seconds ago   Up 40 seconds   8332-8333/tcp, 18332-18333/tcp, 18443-18444/tcp, 28332/tcp, 38332-38333/tcp   btctestnetapi_bitcoincore-testnet_1
610b3d498b87   nginx         "/docker-entrypoint.…"   48 seconds ago   Up 47 seconds   0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp      connector_nginx_1
377429b555e3   connector     "/usr/src/app/Connec…"   48 seconds ago   Up 47 seconds   80/tcp, 28332/tcp                                                             connector_connector_1
```

```sh
curl --location --request POST 'http://localhost:80/btc/testnet/rpc' \
--header 'Content-Type: application/json' \
--data-raw '{
    "id": 1609070896412,
    "method": "syncing",
    "params": {},
    "jsonrpc": "2.0"
}'
```

```js
{
    "id": 1609070896412,
    "jsonrpc": "2.0",
    "result": {
        "syncing": true,
        "syncPercentage": "0.0001525474339549404%",
        "currentBlockIndex": "96",
        "latestBlockIndex": "1879999"
    }
}
```

**Test Configuration**:

* Operating system (output of `sw_vers`): macOS 12.2.1
* Kernel version (output of `uname -sr`): Darwin 21.3.0
* Architecture (output of `uname -m`): x86_64

# Related PR or Docs PR

<!--Please add any related Pull Requests here. -->
Docs PR related # <!--(if any)-->
Other PR related # <!--(if any)-->

# Good practices to consider

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules