### PR TITLE
135 getaddresseshistory is failing sometimes

### DIFF
--- a/Connector/btc/websockets.py
+++ b/Connector/btc/websockets.py
@@ -143,13 +143,10 @@ class BlockWebSocket:
         broker = Broker()
 
         while True:
-
-            logger.printInfo("Esperando bloque BTC")
             payload = await zmqSocket.recv_multipart()
             topic = payload[0].decode("utf-8")
             message = payload[1]
 
-            logger.printInfo("Recibo algo")
             if topic == NEW_HASH_BLOCK_ZMQ_TOPIC:
 
                 blockHash = binascii.hexlify(message).decode("utf-8")

--- a/Connector/tests/btc/test_btc.py
+++ b/Connector/tests/btc/test_btc.py
@@ -286,6 +286,8 @@ def testGetAddressesHistory():
 
     addresses = [address1, address2]
 
+    time.sleep(3)
+
     got = postHttpMethods[COIN_SYMBOL]["getAddressesHistory"]({"addresses": addresses}, config)
 
     for addressHistory in got:


### PR DESCRIPTION
# Description

- Added 3 second sleep before executing `getAddressesHistory` to prevent transactions to stay in the pool.
- Removed some loggers 

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

Fixes #135  (issue)

## Dependencies (if any)

<!--List any dependencies that are required for this change.-->

## Type of change

<!--Please delete options that are not relevant.-->

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **This change requires a documentation update**

# Related PR or Docs PR

<!--Please add any related Pull Requests here. -->
Docs PR related # <!--(if any)-->
Other PR related # <!--(if any)-->

# Good practices to consider

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules