### PR TITLE
ETH indexer container replaced

### DIFF
--- a/docker-compose/mainnet/eth.yml
+++ b/docker-compose/mainnet/eth.yml
@@ -40,13 +40,15 @@ services:
     restart: on-failure
 
   synchroniser-mainnet:
-    image: guenoledc/eth-tx-storage
+    image: nodechain/eth-transactions-indexer
     environment:
       DB_NAME: postgres://swapper_writer:swapper_writer@postgres-mainnet:5432/swapper
-      ETH_URL: ws://ethereumgo-mainnet:8546
-      START_BLOCK: 4370000
-      CONFIRMATIONS_BLOCK: 0
+      NODE_URL: /home/geth.ipc
+      START_BLOCK: 0
+      CONFIRMATIONS: 0
       PERIOD: 20
+    volumes:
+      - ${BLOCKCHAIN_PATH}/ethereumgo:/home
     depends_on:
       ethereumgo-mainnet:
         condition: service_healthy

--- a/docker-compose/regtest/eth.yml
+++ b/docker-compose/regtest/eth.yml
@@ -40,12 +40,12 @@ services:
     restart: on-failure
 
   synchroniser-regtest:
-    image: guenoledc/eth-tx-storage
+    image: nodechain/eth-transactions-indexer
     environment:
       DB_NAME: postgres://swapper_writer:swapper_writer@postgres-regtest:5432/swapper
-      ETH_URL: ws://ethereumgo-regtest:8546
+      NODE_URL: ws://ethereumgo-regtest:8546
       START_BLOCK: 0
-      CONFIRMATIONS_BLOCK: 0
+      CONFIRMATIONS: 0
       PERIOD: 20
     depends_on:
       ethereumgo-regtest:

--- a/docker-compose/testnet/eth.yml
+++ b/docker-compose/testnet/eth.yml
@@ -40,13 +40,15 @@ services:
     restart: on-failure
 
   synchroniser-testnet:
-    image: guenoledc/eth-tx-storage
+    image: nodechain/eth-transactions-indexer
     environment:
       DB_NAME: postgres://swapper_writer:swapper_writer@postgres-testnet:5432/swapper
-      ETH_URL: ws://ethereumgo-testnet:8546
-      START_BLOCK: 1700000
-      CONFIRMATIONS_BLOCK: 0
+      NODE_URL: /home/ropsten/geth.ipc
+      START_BLOCK: 0
+      CONFIRMATIONS: 0
       PERIOD: 20
+    volumes:
+      - ${BLOCKCHAIN_PATH}/ethereumgo:/home
     depends_on:
       ethereumgo-testnet:
         condition: service_healthy


### PR DESCRIPTION
# Description

ETH Transactions indexer container replaced
<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->
Fixes #174 

## Dependencies (if any)

<!--List any dependencies that are required for this change.-->

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **This change requires a documentation update**

# How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. -->
<!--Provide instructions so we can reproduce the changes, if possible add screenshots, gifs or logs to facilitate the work.-->
<!--Please also list any relevant details for your test configuration.-->

- Mainnet deployment

    ```sh
    58ad0b2ee0ab   nodechain/eth-transactions-indexer   "python3.6 ./indexer…"   19 seconds ago   Up 19 seconds                                                                                        ethmainnetapi_synchroniser-mainnet_1
    dac665a4cb91   postgrest/postgrest                  "/bin/postgrest"         34 seconds ago   Up 33 seconds             3000/tcp                                                                   ethmainnetapi_postgrest-mainnet_1
    0041e811e733   ethereum/client-go:latest            "geth --http --http.…"   40 seconds ago   Up 39 seconds (healthy)   8545-8546/tcp, 30303/tcp, 30303/udp                                        ethmainnetapi_ethereumgo-mainnet_1
    3c7ac4e9f5f7   nodechain-ethereum-indexer           "docker-entrypoint.s…"   40 seconds ago   Up 39 seconds (healthy)   5432/tcp                                                                   ethmainnetapi_postgres-mainnet_1
    f08fdd507e08   nginx                                "/docker-entrypoint.…"   45 seconds ago   Up 44 seconds             0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp   connector_nginx_1
    99a9040977ab   connector                            "/usr/src/app/Connec…"   45 seconds ago   Up 44 seconds             80/tcp, 28332/tcp                                                          connector_connector_1
    ```

    Indexer logs 

    ```
    2022-04-27 22:00:06,552 - INFO - Running indexer with following configuration
    2022-04-27 22:00:06,553 - INFO - DB_NAME: postgres://swapper_writer:swapper_writer@postgres-mainnet:5432/swapper
    2022-04-27 22:00:06,553 - INFO - NODE_URL: /home/geth.ipc
    2022-04-27 22:00:06,553 - INFO - START_BLOCK: 0
    2022-04-27 22:00:06,553 - INFO - CONFIRMATIONS: 0
    2022-04-27 22:00:06,553 - INFO - PERIOD: 20
    2022-04-27 22:00:06,553 - INFO - Connecting to /home/geth.ipc
    2022-04-27 22:00:06,558 - INFO - Connected to /home/geth.ipc
    2022-04-27 22:00:06,558 - INFO - Connecting to postgres://swapper_writer:swapper_writer@postgres-mainnet:5432/swapper
    2022-04-27 22:00:06,569 - INFO - Connected to postgres://swapper_writer:swapper_writer@postgres-mainnet:5432/swapper
    2022-04-27 22:00:06,592 - INFO - Node is synchronised. 
    2022-04-27 22:00:06,601 - INFO - Connected to postgres://swapper_writer:swapper_writer@postgres-mainnet:5432/swapper
    2022-04-27 22:00:06,609 - INFO - Current block in index 0. Current block in ETH chain: 21238
    ```

- Testnet deployment
    
    ```
    08fdcdec5b55   postgrest/postgrest                  "/bin/postgrest"         7 seconds ago    Up 6 seconds              3000/tcp                                                                   ethtestnetapi_postgrest-testnet_1
    88f51665b492   nodechain/eth-transactions-indexer   "python3.6 ./indexer…"   7 seconds ago    Up 6 seconds                                                                                         ethtestnetapi_synchroniser-testnet_1
    7b10804b36a8   nodechain-ethereum-indexer           "docker-entrypoint.s…"   19 seconds ago   Up 17 seconds (healthy)   5432/tcp                                                                   ethtestnetapi_postgres-testnet_1
    1a015f232743   ethereum/client-go:latest            "geth --http --http.…"   19 seconds ago   Up 17 seconds (healthy)   8545-8546/tcp, 30303/tcp, 30303/udp                                        ethtestnetapi_ethereumgo-testnet_1
    f08fdd507e08   nginx                                "/docker-entrypoint.…"   20 minutes ago   Up 20 minutes             0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp   connector_nginx_1
    99a9040977ab   connector                            "/usr/src/app/Connec…"   20 minutes ago   Up 20 minutes             80/tcp, 28332/tcp                                                          connector_connector_1
    ```

    Indexer logs

    ```
    2022-04-27 22:19:52,414 - INFO - Running indexer with following configuration
    2022-04-27 22:19:52,414 - INFO - DB_NAME: postgres://swapper_writer:swapper_writer@postgres-testnet:5432/swapper
    2022-04-27 22:19:52,414 - INFO - NODE_URL: /home/ropsten/geth.ipc
    2022-04-27 22:19:52,414 - INFO - START_BLOCK: 0
    2022-04-27 22:19:52,414 - INFO - CONFIRMATIONS: 0
    2022-04-27 22:19:52,414 - INFO - PERIOD: 20
    2022-04-27 22:19:52,415 - INFO - Connecting to /home/ropsten/geth.ipc
    2022-04-27 22:19:52,419 - INFO - Connected to /home/ropsten/geth.ipc
    2022-04-27 22:19:52,419 - INFO - Connecting to postgres://swapper_writer:swapper_writer@postgres-testnet:5432/swapper
    2022-04-27 22:19:52,437 - INFO - Connected to postgres://swapper_writer:swapper_writer@postgres-testnet:5432/swapper
    2022-04-27 22:19:52,459 - INFO - Node is synchronised. 
    2022-04-27 22:19:52,469 - INFO - Connected to postgres://swapper_writer:swapper_writer@postgres-testnet:5432/swapper
    2022-04-27 22:19:52,477 - INFO - Current block in index 16. Current block in ETH chain: 5893
    ```

**Test Configuration**:
* Operating system (output of `cat sw_vers`): macOS 12.2.1
* Kernel version (output of `uname -sr`): Darwin 21.3.0
* Architecture (output of `uname -m`): x86_64

# Related PR or Docs PR

<!--Please add any related Pull Requests here. -->
Docs PR related # <!--(if any)-->
Other PR related # <!--(if any)-->

# Good practices to consider

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules