### PR TITLE
Latest param for get block by number

### DIFF
--- a/Connector/bch/apirpc.py
+++ b/Connector/bch/apirpc.py
@@ -259,7 +259,7 @@ def getBlockByHash(id, params, config):
         raise error.RpcBadRequestError(id=id, message=err.message)
 
     block = RPCConnector.request(
-        endpoint=config.bitcoincoreRpcEndpoint,
+        endpoint=config.config.bitcoinabcRpcEndpoint,
         id=id,
         method=GET_BLOCK_METHOD,
         params=[
@@ -300,7 +300,7 @@ def getBlockByNumber(id, params, config):
     else:
 
         blockHash = RPCConnector.request(
-            endpoint=config.bitcoincoreRpcEndpoint,
+            endpoint=config.config.bitcoinabcRpcEndpoint,
             id=id,
             method=GET_BLOCK_HASH_METHOD,
             params=[

--- a/Connector/bch/apirpc.py
+++ b/Connector/bch/apirpc.py
@@ -250,53 +250,73 @@ def getAddressesUnspent(id, params, config):
 @RpcRouteTableDef.rpc(currency=COIN_SYMBOL)
 @HttpRouteTableDef.post(currency=COIN_SYMBOL)
 def getBlockByHash(id, params, config):
-
     logger.printInfo(f"Executing RPC method getBlockByHash with id {id} and params {params}")
 
     requestSchema, responseSchema = utils.getMethodSchemas(GET_BLOCK_BY_HASH)
 
     err = httputils.validateJSONSchema(params, requestSchema)
     if err is not None:
-        raise error.RpcBadRequestError(err.message)
+        raise error.RpcBadRequestError(id=id, message=err.message)
 
     block = RPCConnector.request(
-        endpoint=config.bitcoinabcRpcEndpoint,
+        endpoint=config.bitcoincoreRpcEndpoint,
         id=id,
         method=GET_BLOCK_METHOD,
         params=[
             params["blockHash"],
-            VERBOSITY_MORE_MODE
+            params["verbosity"] if "verbosity" in params else VERBOSITY_MORE_MODE
         ]
     )
 
-    err = httputils.validateJSONSchema(block, responseSchema)
-    if err is not None:
-        raise error.RpcBadRequestError(err.message)
+    response = {"block": block}
 
-    return block
+    err = httputils.validateJSONSchema(response, responseSchema)
+    if err is not None:
+        raise error.RpcBadRequestError(id=id, message=err.message)
+
+    return response
 
 
 @RpcRouteTableDef.rpc(currency=COIN_SYMBOL)
 @HttpRouteTableDef.post(currency=COIN_SYMBOL)
 def getBlockByNumber(id, params, config):
-
     logger.printInfo(f"Executing RPC method getBlockByNumber with id {id} and params {params}")
 
     requestSchema, responseSchema = utils.getMethodSchemas(GET_BLOCK_BY_NUMBER)
 
     err = httputils.validateJSONSchema(params, requestSchema)
     if err is not None:
-        raise error.RpcBadRequestError(err.message)
+        raise error.RpcBadRequestError(id=id, message=err.message)
 
-    blockHash = RPCConnector.request(
-        endpoint=config.bitcoinabcRpcEndpoint,
-        id=id,
-        method=GET_BLOCK_HASH_METHOD,
-        params=[params["blockNumber"]])
+    if params["blockNumber"] == "latest":
+
+        blockHeight = getHeight(
+            id=id,
+            params={},
+            config=config
+        )
+        blockHash = blockHeight["latestBlockHash"]
+
+    else:
+
+        blockHash = RPCConnector.request(
+            endpoint=config.bitcoincoreRpcEndpoint,
+            id=id,
+            method=GET_BLOCK_HASH_METHOD,
+            params=[
+                int(
+                    params["blockNumber"],
+                    (16 if utils.isHexNumber(params["blockNumber"]) else 10)
+                )
+            ]
+        )
 
     return getBlockByHash(
         id=id,
-        params={"blockHash": blockHash},
+        params={
+            "blockHash": blockHash,
+            "verbosity": params["verbosity"] if "verbosity" in params else VERBOSITY_MORE_MODE
+        },
         config=config
     )
 

--- a/Connector/bch/rpcschemas/getblockbyhash_request.json
+++ b/Connector/bch/rpcschemas/getblockbyhash_request.json
@@ -6,6 +6,14 @@
     "properties": {
         "blockHash" : {
             "type": "string"
+        },
+        "verbosity": {
+            "type": "integer",
+            "enum": [
+                0,
+                1,
+                2
+            ]
         }
     },
     "required": [

--- a/Connector/bch/rpcschemas/getblockbyhash_response.json
+++ b/Connector/bch/rpcschemas/getblockbyhash_response.json
@@ -4,150 +4,161 @@
     "description": "",
     "type": "object",
     "properties": {
-        "hash": {
-            "type": "string"
-        },
-        "confirmations": {
-            "type": "integer"
-        },
-        "strippedsize": {
-            "type": "integer"
-        },
-        "weight": {
-            "type": "integer"
-        },
-        "height": {
-            "type": "integer"
-        },
-        "version": {
-            "type": "number"
-        },
-        "versionHex": {
-            "type": "string"
-        },
-        "time": {
-            "type": "integer"
-        },
-        "mediantime": {
-            "type": "integer"
-        },
-        "nonce": {
-            "type": "integer"
-        },
-        "bits": {
-            "type": "string"
-        },
-        "difficulty": {
-            "type": "number"
-        },
-        "chainwork": {
-            "type": "string"
-        },
-        "nTx": {
-            "type": "integer"
-        },
-        "previousblockhash": {
-            "type": "string"
-        },
-        "nextblockhash": {
-            "type": "string"
-        },
-        "tx": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "txid": {
-                        "type": "string"
-                    },
-                    "hash": {
-                        "type": "string"
-                    },
-                    "version": {
-                        "type": "integer"
-                    },
-                    "size": {
-                        "type": "integer"
-                    },
-                    "vsize": {
-                        "type": "integer"
-                    },
-                    "weight": {
-                        "type": "integer"
-                    },
-                    "locktime": {
-                        "type": "integer"
-                    },
-                    "hex": {
-                        "type": "string"
-                    },
-                    "vin": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "coinbase": {
-                                    "type": "string"
-                                },
-                                "sequence": {
-                                    "type": "integer"
-                                },
-                                "txid": {
-                                    "type": "string"
-                                },
-                                "vout": {
-                                    "type": "integer"
-                                },
-                                "scriptSig": {
+        "block": {
+            "type": [
+                "object",
+                "string"
+            ],
+            "properties": {
+                "hash": {
+                    "type": "string"
+                },
+                "confirmations": {
+                    "type": "integer"
+                },
+                "strippedsize": {
+                    "type": "integer"
+                },
+                "weight": {
+                    "type": "integer"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "number"
+                },
+                "versionHex": {
+                    "type": "string"
+                },
+                "time": {
+                    "type": "integer"
+                },
+                "mediantime": {
+                    "type": "integer"
+                },
+                "nonce": {
+                    "type": "integer"
+                },
+                "bits": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "number"
+                },
+                "chainwork": {
+                    "type": "string"
+                },
+                "nTx": {
+                    "type": "integer"
+                },
+                "previousblockhash": {
+                    "type": "string"
+                },
+                "nextblockhash": {
+                    "type": "string"
+                },
+                "tx": {
+                    "type": "array",
+                    "items": {
+                        "type": [
+                            "object",
+                            "string"
+                        ],
+                        "properties": {
+                            "txid": {
+                                "type": "string"
+                            },
+                            "hash": {
+                                "type": "string"
+                            },
+                            "version": {
+                                "type": "integer"
+                            },
+                            "size": {
+                                "type": "integer"
+                            },
+                            "vsize": {
+                                "type": "integer"
+                            },
+                            "weight": {
+                                "type": "integer"
+                            },
+                            "locktime": {
+                                "type": "integer"
+                            },
+                            "hex": {
+                                "type": "string"
+                            },
+                            "vin": {
+                                "type": "array",
+                                "items": {
                                     "type": "object",
                                     "properties": {
-                                        "asm": {
+                                        "coinbase": {
                                             "type": "string"
                                         },
-                                        "hex": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "txinwitness": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "vout": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "value": {
-                                    "type": "number"
-                                },
-                                "n": {
-                                    "type": "integer"
-                                },
-                                "scriptPubKey": {
-                                    "type": "object",
-                                    "properties": {
-                                        "asm": {
-                                            "type": "string"
-                                        },
-                                        "hex": {
-                                            "type": "string"
-                                        },
-                                        "reqSigs": {
+                                        "sequence": {
                                             "type": "integer"
                                         },
-                                        "type": {
+                                        "txid": {
                                             "type": "string"
                                         },
-                                        "addresses": {
+                                        "vout": {
+                                            "type": "integer"
+                                        },
+                                        "scriptSig": {
+                                            "type": "object",
+                                            "properties": {
+                                                "asm": {
+                                                    "type": "string"
+                                                },
+                                                "hex": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "txinwitness": {
                                             "type": "array",
                                             "items": {
                                                 "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "vout": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "value": {
+                                            "type": "number"
+                                        },
+                                        "n": {
+                                            "type": "integer"
+                                        },
+                                        "scriptPubKey": {
+                                            "type": "object",
+                                            "properties": {
+                                                "asm": {
+                                                    "type": "string"
+                                                },
+                                                "hex": {
+                                                    "type": "string"
+                                                },
+                                                "reqSigs": {
+                                                    "type": "integer"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                },
+                                                "addresses": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/Connector/bch/rpcschemas/getblockbynumber_request.json
+++ b/Connector/bch/rpcschemas/getblockbynumber_request.json
@@ -4,8 +4,29 @@
     "description": "",
     "type": "object",
     "properties": {
-        "blockNumber" : {
-            "type": "integer"
+        "blockNumber": {
+            "type": "string",
+            "oneOf": [
+               {
+                   "pattern": "^[0-9]+$"
+               },
+               {
+                   "enum": [
+                       "latest"
+                   ]
+               },
+               {
+                   "pattern": "0[xX][0-9a-fA-F]"
+               }
+            ]
+        },
+        "verbosity": {
+            "type": "integer",
+            "enum": [
+                0,
+                1,
+                2
+            ]
         }
     },
     "required": [

--- a/Connector/bch/rpcschemas/getblockbynumber_response.json
+++ b/Connector/bch/rpcschemas/getblockbynumber_response.json
@@ -4,150 +4,161 @@
     "description": "",
     "type": "object",
     "properties": {
-        "hash": {
-            "type": "string"
-        },
-        "confirmations": {
-            "type": "integer"
-        },
-        "strippedsize": {
-            "type": "integer"
-        },
-        "weight": {
-            "type": "integer"
-        },
-        "height": {
-            "type": "integer"
-        },
-        "version": {
-            "type": "number"
-        },
-        "versionHex": {
-            "type": "string"
-        },
-        "time": {
-            "type": "integer"
-        },
-        "mediantime": {
-            "type": "integer"
-        },
-        "nonce": {
-            "type": "integer"
-        },
-        "bits": {
-            "type": "string"
-        },
-        "difficulty": {
-            "type": "number"
-        },
-        "chainwork": {
-            "type": "string"
-        },
-        "nTx": {
-            "type": "integer"
-        },
-        "previousblockhash": {
-            "type": "string"
-        },
-        "nextblockhash": {
-            "type": "string"
-        },
-        "tx": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "txid": {
-                        "type": "string"
-                    },
-                    "hash": {
-                        "type": "string"
-                    },
-                    "version": {
-                        "type": "integer"
-                    },
-                    "size": {
-                        "type": "integer"
-                    },
-                    "vsize": {
-                        "type": "integer"
-                    },
-                    "weight": {
-                        "type": "integer"
-                    },
-                    "locktime": {
-                        "type": "integer"
-                    },
-                    "hex": {
-                        "type": "string"
-                    },
-                    "vin": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "coinbase": {
-                                    "type": "string"
-                                },
-                                "sequence": {
-                                    "type": "integer"
-                                },
-                                "txid": {
-                                    "type": "string"
-                                },
-                                "vout": {
-                                    "type": "integer"
-                                },
-                                "scriptSig": {
+        "block": {
+            "type": [
+                "object",
+                "string"
+            ],
+            "properties": {
+                "hash": {
+                    "type": "string"
+                },
+                "confirmations": {
+                    "type": "integer"
+                },
+                "strippedsize": {
+                    "type": "integer"
+                },
+                "weight": {
+                    "type": "integer"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "number"
+                },
+                "versionHex": {
+                    "type": "string"
+                },
+                "time": {
+                    "type": "integer"
+                },
+                "mediantime": {
+                    "type": "integer"
+                },
+                "nonce": {
+                    "type": "integer"
+                },
+                "bits": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "number"
+                },
+                "chainwork": {
+                    "type": "string"
+                },
+                "nTx": {
+                    "type": "integer"
+                },
+                "previousblockhash": {
+                    "type": "string"
+                },
+                "nextblockhash": {
+                    "type": "string"
+                },
+                "tx": {
+                    "type": "array",
+                    "items": {
+                        "type": [
+                            "object",
+                            "string"
+                        ],
+                        "properties": {
+                            "txid": {
+                                "type": "string"
+                            },
+                            "hash": {
+                                "type": "string"
+                            },
+                            "version": {
+                                "type": "integer"
+                            },
+                            "size": {
+                                "type": "integer"
+                            },
+                            "vsize": {
+                                "type": "integer"
+                            },
+                            "weight": {
+                                "type": "integer"
+                            },
+                            "locktime": {
+                                "type": "integer"
+                            },
+                            "hex": {
+                                "type": "string"
+                            },
+                            "vin": {
+                                "type": "array",
+                                "items": {
                                     "type": "object",
                                     "properties": {
-                                        "asm": {
+                                        "coinbase": {
                                             "type": "string"
                                         },
-                                        "hex": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "txinwitness": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "vout": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "value": {
-                                    "type": "number"
-                                },
-                                "n": {
-                                    "type": "integer"
-                                },
-                                "scriptPubKey": {
-                                    "type": "object",
-                                    "properties": {
-                                        "asm": {
-                                            "type": "string"
-                                        },
-                                        "hex": {
-                                            "type": "string"
-                                        },
-                                        "reqSigs": {
+                                        "sequence": {
                                             "type": "integer"
                                         },
-                                        "type": {
+                                        "txid": {
                                             "type": "string"
                                         },
-                                        "addresses": {
+                                        "vout": {
+                                            "type": "integer"
+                                        },
+                                        "scriptSig": {
+                                            "type": "object",
+                                            "properties": {
+                                                "asm": {
+                                                    "type": "string"
+                                                },
+                                                "hex": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "txinwitness": {
                                             "type": "array",
                                             "items": {
                                                 "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "vout": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "value": {
+                                            "type": "number"
+                                        },
+                                        "n": {
+                                            "type": "integer"
+                                        },
+                                        "scriptPubKey": {
+                                            "type": "object",
+                                            "properties": {
+                                                "asm": {
+                                                    "type": "string"
+                                                },
+                                                "hex": {
+                                                    "type": "string"
+                                                },
+                                                "reqSigs": {
+                                                    "type": "integer"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                },
+                                                "addresses": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/Connector/bch/utils.py
+++ b/Connector/bch/utils.py
@@ -73,3 +73,7 @@ def sortUnspentOutputs(outputs):
         return outputs['txHash']
     except KeyError:
         return ''
+
+
+def isHexNumber(number: str):
+    return any(number.startswith(prefix) for prefix in ["0x", "0X"])

--- a/Connector/btc/apirpc.py
+++ b/Connector/btc/apirpc.py
@@ -247,11 +247,13 @@ def getBlockByHash(id, params, config):
         ]
     )
 
-    err = httputils.validateJSONSchema(block, responseSchema)
+    response = {"block": block}
+
+    err = httputils.validateJSONSchema(response, responseSchema)
     if err is not None:
         raise error.RpcBadRequestError(id=id, message=err.message)
 
-    return block
+    return response
 
 
 @RpcRouteTableDef.rpc(currency=COIN_SYMBOL)
@@ -266,12 +268,28 @@ def getBlockByNumber(id, params, config):
     if err is not None:
         raise error.RpcBadRequestError(id=id, message=err.message)
 
-    blockHash = RPCConnector.request(
-        endpoint=config.bitcoincoreRpcEndpoint,
-        id=id,
-        method=GET_BLOCK_HASH_METHOD,
-        params=[params["blockNumber"]]
-    )
+    if params["blockNumber"] == "latest":
+
+        blockHeight = getHeight(
+            id=id,
+            params={},
+            config=config
+        )
+        blockHash = blockHeight["latestBlockHash"]
+
+    else:
+
+        blockHash = RPCConnector.request(
+            endpoint=config.bitcoincoreRpcEndpoint,
+            id=id,
+            method=GET_BLOCK_HASH_METHOD,
+            params=[
+                int(
+                    params["blockNumber"],
+                    (16 if utils.isHexNumber(params["blockNumber"]) else 10)
+                )
+            ]
+        )
 
     return getBlockByHash(
         id=id,

--- a/Connector/btc/apirpc.py
+++ b/Connector/btc/apirpc.py
@@ -440,8 +440,8 @@ def getTransaction(id, params, config):
                 },
                 config=config
             )
-            blockNumber = transactionBlock["height"]
-            timestamp = transactionBlock["time"]
+            blockNumber = transactionBlock["block"]["height"]
+            timestamp = transactionBlock["block"]["time"]
 
         transactionDetails = utils.decodeTransactionDetails(transaction["rawTransaction"], id, config)
 

--- a/Connector/btc/rpcschemas/getblockbyhash_response.json
+++ b/Connector/btc/rpcschemas/getblockbyhash_response.json
@@ -2,158 +2,163 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "title": "",
     "description": "",
-    "type": [
-        "object",
-        "string"
-    ],
+    "type": "object",
     "properties": {
-        "hash": {
-            "type": "string"
-        },
-        "confirmations": {
-            "type": "integer"
-        },
-        "strippedsize": {
-            "type": "integer"
-        },
-        "weight": {
-            "type": "integer"
-        },
-        "height": {
-            "type": "integer"
-        },
-        "version": {
-            "type": "number"
-        },
-        "versionHex": {
-            "type": "string"
-        },
-        "time": {
-            "type": "integer"
-        },
-        "mediantime": {
-            "type": "integer"
-        },
-        "nonce": {
-            "type": "integer"
-        },
-        "bits": {
-            "type": "string"
-        },
-        "difficulty": {
-            "type": "number"
-        },
-        "chainwork": {
-            "type": "string"
-        },
-        "nTx": {
-            "type": "integer"
-        },
-        "previousblockhash": {
-            "type": "string"
-        },
-        "nextblockhash": {
-            "type": "string"
-        },
-        "tx": {
-            "type": "array",
-            "items": {
-                "type": [
-                    "object",
-                    "string"
-                ],
-                "properties": {
-                    "txid": {
-                        "type": "string"
-                    },
-                    "hash": {
-                        "type": "string"
-                    },
-                    "version": {
-                        "type": "integer"
-                    },
-                    "size": {
-                        "type": "integer"
-                    },
-                    "vsize": {
-                        "type": "integer"
-                    },
-                    "weight": {
-                        "type": "integer"
-                    },
-                    "locktime": {
-                        "type": "integer"
-                    },
-                    "hex": {
-                        "type": "string"
-                    },
-                    "vin": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "coinbase": {
-                                    "type": "string"
-                                },
-                                "sequence": {
-                                    "type": "integer"
-                                },
-                                "txid": {
-                                    "type": "string"
-                                },
-                                "vout": {
-                                    "type": "integer"
-                                },
-                                "scriptSig": {
+        "block": {
+            "type": [
+                "object",
+                "string"
+            ],
+            "properties": {
+                "hash": {
+                    "type": "string"
+                },
+                "confirmations": {
+                    "type": "integer"
+                },
+                "strippedsize": {
+                    "type": "integer"
+                },
+                "weight": {
+                    "type": "integer"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "number"
+                },
+                "versionHex": {
+                    "type": "string"
+                },
+                "time": {
+                    "type": "integer"
+                },
+                "mediantime": {
+                    "type": "integer"
+                },
+                "nonce": {
+                    "type": "integer"
+                },
+                "bits": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "number"
+                },
+                "chainwork": {
+                    "type": "string"
+                },
+                "nTx": {
+                    "type": "integer"
+                },
+                "previousblockhash": {
+                    "type": "string"
+                },
+                "nextblockhash": {
+                    "type": "string"
+                },
+                "tx": {
+                    "type": "array",
+                    "items": {
+                        "type": [
+                            "object",
+                            "string"
+                        ],
+                        "properties": {
+                            "txid": {
+                                "type": "string"
+                            },
+                            "hash": {
+                                "type": "string"
+                            },
+                            "version": {
+                                "type": "integer"
+                            },
+                            "size": {
+                                "type": "integer"
+                            },
+                            "vsize": {
+                                "type": "integer"
+                            },
+                            "weight": {
+                                "type": "integer"
+                            },
+                            "locktime": {
+                                "type": "integer"
+                            },
+                            "hex": {
+                                "type": "string"
+                            },
+                            "vin": {
+                                "type": "array",
+                                "items": {
                                     "type": "object",
                                     "properties": {
-                                        "asm": {
+                                        "coinbase": {
                                             "type": "string"
                                         },
-                                        "hex": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "txinwitness": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "vout": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "value": {
-                                    "type": "number"
-                                },
-                                "n": {
-                                    "type": "integer"
-                                },
-                                "scriptPubKey": {
-                                    "type": "object",
-                                    "properties": {
-                                        "asm": {
-                                            "type": "string"
-                                        },
-                                        "hex": {
-                                            "type": "string"
-                                        },
-                                        "reqSigs": {
+                                        "sequence": {
                                             "type": "integer"
                                         },
-                                        "type": {
+                                        "txid": {
                                             "type": "string"
                                         },
-                                        "addresses": {
+                                        "vout": {
+                                            "type": "integer"
+                                        },
+                                        "scriptSig": {
+                                            "type": "object",
+                                            "properties": {
+                                                "asm": {
+                                                    "type": "string"
+                                                },
+                                                "hex": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "txinwitness": {
                                             "type": "array",
                                             "items": {
                                                 "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "vout": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "value": {
+                                            "type": "number"
+                                        },
+                                        "n": {
+                                            "type": "integer"
+                                        },
+                                        "scriptPubKey": {
+                                            "type": "object",
+                                            "properties": {
+                                                "asm": {
+                                                    "type": "string"
+                                                },
+                                                "hex": {
+                                                    "type": "string"
+                                                },
+                                                "reqSigs": {
+                                                    "type": "integer"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                },
+                                                "addresses": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/Connector/btc/rpcschemas/getblockbynumber_request.json
+++ b/Connector/btc/rpcschemas/getblockbynumber_request.json
@@ -4,8 +4,21 @@
     "description": "",
     "type": "object",
     "properties": {
-        "blockNumber" : {
-            "type": "integer"
+        "blockNumber": {
+            "type": "string",
+            "oneOf": [
+               {
+                   "pattern": "^[0-9]+$"
+               },
+               {
+                   "enum": [
+                       "latest"
+                   ]
+               },
+               {
+                   "pattern": "0[xX][0-9a-fA-F]"
+               }
+            ]
         },
         "verbosity": {
             "type": "integer",

--- a/Connector/btc/rpcschemas/getblockbynumber_response.json
+++ b/Connector/btc/rpcschemas/getblockbynumber_response.json
@@ -2,158 +2,163 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "title": "",
     "description": "",
-    "type": [
-        "object",
-        "string"
-    ],
+    "type": "object",
     "properties": {
-        "hash": {
-            "type": "string"
-        },
-        "confirmations": {
-            "type": "integer"
-        },
-        "strippedsize": {
-            "type": "integer"
-        },
-        "weight": {
-            "type": "integer"
-        },
-        "height": {
-            "type": "integer"
-        },
-        "version": {
-            "type": "number"
-        },
-        "versionHex": {
-            "type": "string"
-        },
-        "time": {
-            "type": "integer"
-        },
-        "mediantime": {
-            "type": "integer"
-        },
-        "nonce": {
-            "type": "integer"
-        },
-        "bits": {
-            "type": "string"
-        },
-        "difficulty": {
-            "type": "number"
-        },
-        "chainwork": {
-            "type": "string"
-        },
-        "nTx": {
-            "type": "integer"
-        },
-        "previousblockhash": {
-            "type": "string"
-        },
-        "nextblockhash": {
-            "type": "string"
-        },
-        "tx": {
-            "type": "array",
-            "items": {
-                "type": [
-                    "object",
-                    "string"
-                ],
-                "properties": {
-                    "txid": {
-                        "type": "string"
-                    },
-                    "hash": {
-                        "type": "string"
-                    },
-                    "version": {
-                        "type": "integer"
-                    },
-                    "size": {
-                        "type": "integer"
-                    },
-                    "vsize": {
-                        "type": "integer"
-                    },
-                    "weight": {
-                        "type": "integer"
-                    },
-                    "locktime": {
-                        "type": "integer"
-                    },
-                    "hex": {
-                        "type": "string"
-                    },
-                    "vin": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "coinbase": {
-                                    "type": "string"
-                                },
-                                "sequence": {
-                                    "type": "integer"
-                                },
-                                "txid": {
-                                    "type": "string"
-                                },
-                                "vout": {
-                                    "type": "integer"
-                                },
-                                "scriptSig": {
+        "block": {
+            "type": [
+                "object",
+                "string"
+            ],
+            "properties": {
+                "hash": {
+                    "type": "string"
+                },
+                "confirmations": {
+                    "type": "integer"
+                },
+                "strippedsize": {
+                    "type": "integer"
+                },
+                "weight": {
+                    "type": "integer"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "number"
+                },
+                "versionHex": {
+                    "type": "string"
+                },
+                "time": {
+                    "type": "integer"
+                },
+                "mediantime": {
+                    "type": "integer"
+                },
+                "nonce": {
+                    "type": "integer"
+                },
+                "bits": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "number"
+                },
+                "chainwork": {
+                    "type": "string"
+                },
+                "nTx": {
+                    "type": "integer"
+                },
+                "previousblockhash": {
+                    "type": "string"
+                },
+                "nextblockhash": {
+                    "type": "string"
+                },
+                "tx": {
+                    "type": "array",
+                    "items": {
+                        "type": [
+                            "object",
+                            "string"
+                        ],
+                        "properties": {
+                            "txid": {
+                                "type": "string"
+                            },
+                            "hash": {
+                                "type": "string"
+                            },
+                            "version": {
+                                "type": "integer"
+                            },
+                            "size": {
+                                "type": "integer"
+                            },
+                            "vsize": {
+                                "type": "integer"
+                            },
+                            "weight": {
+                                "type": "integer"
+                            },
+                            "locktime": {
+                                "type": "integer"
+                            },
+                            "hex": {
+                                "type": "string"
+                            },
+                            "vin": {
+                                "type": "array",
+                                "items": {
                                     "type": "object",
                                     "properties": {
-                                        "asm": {
+                                        "coinbase": {
                                             "type": "string"
                                         },
-                                        "hex": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "txinwitness": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "vout": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "value": {
-                                    "type": "number"
-                                },
-                                "n": {
-                                    "type": "integer"
-                                },
-                                "scriptPubKey": {
-                                    "type": "object",
-                                    "properties": {
-                                        "asm": {
-                                            "type": "string"
-                                        },
-                                        "hex": {
-                                            "type": "string"
-                                        },
-                                        "reqSigs": {
+                                        "sequence": {
                                             "type": "integer"
                                         },
-                                        "type": {
+                                        "txid": {
                                             "type": "string"
                                         },
-                                        "addresses": {
+                                        "vout": {
+                                            "type": "integer"
+                                        },
+                                        "scriptSig": {
+                                            "type": "object",
+                                            "properties": {
+                                                "asm": {
+                                                    "type": "string"
+                                                },
+                                                "hex": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "txinwitness": {
                                             "type": "array",
                                             "items": {
                                                 "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "vout": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "value": {
+                                            "type": "number"
+                                        },
+                                        "n": {
+                                            "type": "integer"
+                                        },
+                                        "scriptPubKey": {
+                                            "type": "object",
+                                            "properties": {
+                                                "asm": {
+                                                    "type": "string"
+                                                },
+                                                "hex": {
+                                                    "type": "string"
+                                                },
+                                                "reqSigs": {
+                                                    "type": "integer"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                },
+                                                "addresses": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/Connector/btc/utils.py
+++ b/Connector/btc/utils.py
@@ -144,3 +144,7 @@ def sortUnspentOutputs(outputs):
         return outputs['txHash']
     except KeyError:
         return ''
+
+
+def isHexNumber(number: str):
+    return any(number.startswith(prefix) for prefix in ["0x", "0X"])

--- a/Connector/eth/apirpc.py
+++ b/Connector/eth/apirpc.py
@@ -230,7 +230,7 @@ def getTransaction(id, params, config):
             config=config
         )
 
-        timestamp = block["timestamp"]
+        timestamp = block["block"]["timestamp"]
 
     response = {
         "transaction": {

--- a/Connector/eth/apirpc.py
+++ b/Connector/eth/apirpc.py
@@ -334,14 +334,16 @@ def getBlockByHash(id, params, config):
             id=id,
             message=f"Block with hash {params['blockHash']} could not be retrieve from node")
 
-    err = httputils.validateJSONSchema(block, responseSchema)
+    response = {"block": block}
+
+    err = httputils.validateJSONSchema(response, responseSchema)
     if err is not None:
         raise error.RpcBadRequestError(
             id=id,
             message=err.message
         )
 
-    return block
+    return response
 
 
 @RpcRouteTableDef.rpc(currency=COIN_SYMBOL)
@@ -558,7 +560,7 @@ def getBlockByNumber(id, params, config):
 
     blockNumber = params["blockNumber"]
 
-    if blockNumber != "latest" and not blockNumber.startswith('0x'):
+    if blockNumber != "latest" and not utils.isHexNumber(blockNumber):
         blockNumber = hex(int(blockNumber))
 
     block = RPCConnector.request(
@@ -577,14 +579,16 @@ def getBlockByNumber(id, params, config):
             message=f"Block number {blockNumber} could not be retrieve from node"
         )
 
-    err = httputils.validateJSONSchema(block, responseSchema)
+    response = {"block": block}
+
+    err = httputils.validateJSONSchema(response, responseSchema)
     if err is not None:
         raise error.RpcBadRequestError(
             id=id,
             message=err.message
         )
 
-    return block
+    return response
 
 
 @RpcRouteTableDef.rpc(currency=COIN_SYMBOL)

--- a/Connector/eth/apirpc.py
+++ b/Connector/eth/apirpc.py
@@ -325,7 +325,7 @@ def getBlockByHash(id, params, config):
         method=GET_BLOCK_BY_HASH_METHOD,
         params=[
             params["blockHash"],
-            True
+            True if "verbosity" not in params else params["verbosity"] == VERBOSITY_MORE_MODE
         ]
     )
 
@@ -556,18 +556,19 @@ def getBlockByNumber(id, params, config):
             message=err.message
         )
 
-    if isinstance(params["blockNumber"], int):
-        blockNumber = hex(params["blockNumber"])
-    elif not params["blockNumber"].startswith('0x'):
-        blockNumber = hex(int(params["blockNumber"]))
-    else:
-        blockNumber = params["blockNumber"]
+    blockNumber = params["blockNumber"]
+
+    if blockNumber != "latest" and not blockNumber.startswith('0x'):
+        blockNumber = hex(int(blockNumber))
 
     block = RPCConnector.request(
         endpoint=config.rpcEndpoint,
         id=id,
         method=GET_BLOCK_BY_NUMBER_METHOD,
-        params=[blockNumber, True]
+        params=[
+            blockNumber,
+            True if "verbosity" not in params else params["verbosity"] == VERBOSITY_MORE_MODE
+        ]
     )
 
     if block is None:

--- a/Connector/eth/constants.py
+++ b/Connector/eth/constants.py
@@ -50,5 +50,8 @@ INDEXER_TXS_PATH = "/ethtxs"
 INDEXER_MAX_BLOCK_PATH = "/max_block"
 GRAPHQL_PATH = "/graphql"
 
+VERBOSITY_MORE_MODE = 2
+VERBOSITY_LESS_MODE = 1
+
 COIN_SYMBOL = "eth"
 DEFAULT_PKG_CONF = "defaultConf.json"

--- a/Connector/eth/rpcschemas/getblockbyhash_request.json
+++ b/Connector/eth/rpcschemas/getblockbyhash_request.json
@@ -6,6 +6,13 @@
     "properties": {
         "blockHash" : {
             "type": "string"
+        },
+        "verbosity": {
+            "type": "integer",
+            "enum": [
+                1,
+                2
+            ]
         }
     },
     "required": [

--- a/Connector/eth/rpcschemas/getblockbyhash_response.json
+++ b/Connector/eth/rpcschemas/getblockbyhash_response.json
@@ -4,125 +4,133 @@
     "description": "",
     "type": "object",
     "properties": {
-        "number": {
-            "type": "string"
-        },
-        "hash": {
-            "type": "string"
-        },
-        "parentHash": {
-            "type": "string"
-        },
-        "mixHash": {
-            "type": "string"
-        },
-        "nonce": {
-            "type": "string"
-        },
-        "sha3Uncles": {
-            "type": "string"
-        },
-        "logsBloom": {
-            "type": "string"
-        },
-        "transactionsRoot": {
-            "type": "string"
-        },
-        "stateRoot": {
-            "type": "string"
-        },
-        "receiptsRoot": {
-            "type": "string"
-        },
-        "miner": {
-            "type": "string"
-        },
-        "difficulty": {
-            "type": "string"
-        },
-        "totalDifficulty": {
-            "type": "string"
-        },
-        "extraData": {
-            "type": "string"
-        },
-        "size": {
-            "type": "string"
-        },
-        "gasLimit": {
-            "type": "string"
-        },
-        "gasUsed": {
-            "type": "string"
-        },
-        "timestamp": {
-            "type": "string"
-        },
-        "transactions": {
-            "type": "array",
-            "items": {
-                "oneOf": [
-                    {
-                        "type": "string"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "blockHash": {
+        "block": {
+            "type": "object",
+            "properties": {
+                "number": {
+                    "type": "string"
+                },
+                "hash": {
+                    "type": "string"
+                },
+                "parentHash": {
+                    "type": "string"
+                },
+                "mixHash": {
+                    "type": "string"
+                },
+                "nonce": {
+                    "type": "string"
+                },
+                "sha3Uncles": {
+                    "type": "string"
+                },
+                "logsBloom": {
+                    "type": "string"
+                },
+                "transactionsRoot": {
+                    "type": "string"
+                },
+                "stateRoot": {
+                    "type": "string"
+                },
+                "receiptsRoot": {
+                    "type": "string"
+                },
+                "miner": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "string"
+                },
+                "totalDifficulty": {
+                    "type": "string"
+                },
+                "extraData": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "string"
+                },
+                "gasLimit": {
+                    "type": "string"
+                },
+                "gasUsed": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                },
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
                                 "type": "string"
                             },
-                            "blockNumber": {
-                                "type": "string"
-                            },
-                            "from": {
-                                "type": "string"
-                            },
-                            "gas": {
-                                "type": "string"
-                            },
-                            "gasPrice": {
-                                "type": "string"
-                            },
-                            "hash": {
-                                "type": "string"
-                            },
-                            "input": {
-                                "type": "string"
-                            },
-                            "nonce": {
-                                "type": "string"
-                            },
-                            "r": {
-                                "type": "string"
-                            },
-                            "s": {
-                                "type": "string"
-                            },
-                            "to": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
-                            },
-                            "transactionIndex": {
-                                "type": "string"
-                            },
-                            "v": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "string"
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "blockHash": {
+                                        "type": "string"
+                                    },
+                                    "blockNumber": {
+                                        "type": "string"
+                                    },
+                                    "from": {
+                                        "type": "string"
+                                    },
+                                    "gas": {
+                                        "type": "string"
+                                    },
+                                    "gasPrice": {
+                                        "type": "string"
+                                    },
+                                    "hash": {
+                                        "type": "string"
+                                    },
+                                    "input": {
+                                        "type": "string"
+                                    },
+                                    "nonce": {
+                                        "type": "string"
+                                    },
+                                    "r": {
+                                        "type": "string"
+                                    },
+                                    "s": {
+                                        "type": "string"
+                                    },
+                                    "to": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "transactionIndex": {
+                                        "type": "string"
+                                    },
+                                    "v": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                }
                             }
-                        }
+                        ]
                     }
-                ]
-            }
-        },
-        "uncles": {
-            "type": "array",
-            "items": {
-                "type": "string"
+                },
+                "uncles": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
             }
         }
-    }
+    },
+    "required": [
+        "block"
+    ]
 }

--- a/Connector/eth/rpcschemas/getblockbyhash_response.json
+++ b/Connector/eth/rpcschemas/getblockbyhash_response.json
@@ -61,54 +61,61 @@
         "transactions": {
             "type": "array",
             "items": {
-                "type": "object",
-                "properties": {
-                    "blockHash": {
+                "oneOf": [
+                    {
                         "type": "string"
                     },
-                    "blockNumber": {
-                        "type": "string"
-                    },
-                    "from": {
-                        "type": "string"
-                    },
-                    "gas": {
-                        "type": "string"
-                    },
-                    "gasPrice": {
-                        "type": "string"
-                    },
-                    "hash": {
-                        "type": "string"
-                    },
-                    "input": {
-                        "type": "string"
-                    },
-                    "nonce": {
-                        "type": "string"
-                    },
-                    "r": {
-                        "type": "string"
-                    },
-                    "s": {
-                        "type": "string"
-                    },
-                    "to": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "transactionIndex": {
-                        "type": "string"
-                    },
-                    "v": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "type": "string"
+                    {
+                        "type": "object",
+                        "properties": {
+                            "blockHash": {
+                                "type": "string"
+                            },
+                            "blockNumber": {
+                                "type": "string"
+                            },
+                            "from": {
+                                "type": "string"
+                            },
+                            "gas": {
+                                "type": "string"
+                            },
+                            "gasPrice": {
+                                "type": "string"
+                            },
+                            "hash": {
+                                "type": "string"
+                            },
+                            "input": {
+                                "type": "string"
+                            },
+                            "nonce": {
+                                "type": "string"
+                            },
+                            "r": {
+                                "type": "string"
+                            },
+                            "s": {
+                                "type": "string"
+                            },
+                            "to": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "transactionIndex": {
+                                "type": "string"
+                            },
+                            "v": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
                     }
-                }
+                ]
             }
         },
         "uncles": {

--- a/Connector/eth/rpcschemas/getblockbynumber_request.json
+++ b/Connector/eth/rpcschemas/getblockbynumber_request.json
@@ -5,8 +5,26 @@
     "type": "object",
     "properties": {
         "blockNumber": {
-            "type": [
-                "string"
+            "type": "string",
+            "oneOf": [
+               {
+                   "pattern": "^[0-9]+$"
+               },
+               {
+                   "enum": [
+                       "latest"
+                   ]
+               },
+               {
+                   "pattern": "0[xX][0-9a-fA-F]"
+               }
+            ]
+        },
+        "verbosity": {
+            "type": "integer",
+            "enum": [
+                1,
+                2
             ]
         }
     },

--- a/Connector/eth/rpcschemas/getblockbynumber_response.json
+++ b/Connector/eth/rpcschemas/getblockbynumber_response.json
@@ -4,125 +4,133 @@
     "description": "",
     "type": "object",
     "properties": {
-        "number": {
-            "type": "string"
-        },
-        "hash": {
-            "type": "string"
-        },
-        "parentHash": {
-            "type": "string"
-        },
-        "mixHash": {
-            "type": "string"
-        },
-        "nonce": {
-            "type": "string"
-        },
-        "sha3Uncles": {
-            "type": "string"
-        },
-        "logsBloom": {
-            "type": "string"
-        },
-        "transactionsRoot": {
-            "type": "string"
-        },
-        "stateRoot": {
-            "type": "string"
-        },
-        "receiptsRoot": {
-            "type": "string"
-        },
-        "miner": {
-            "type": "string"
-        },
-        "difficulty": {
-            "type": "string"
-        },
-        "totalDifficulty": {
-            "type": "string"
-        },
-        "extraData": {
-            "type": "string"
-        },
-        "size": {
-            "type": "string"
-        },
-        "gasLimit": {
-            "type": "string"
-        },
-        "gasUsed": {
-            "type": "string"
-        },
-        "timestamp": {
-            "type": "string"
-        },
-        "transactions": {
-            "type": "array",
-            "items": {
-                "oneOf": [
-                    {
-                        "type": "string"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "blockHash": {
+        "block": {
+            "type": "object",
+            "properties": {
+                "number": {
+                    "type": "string"
+                },
+                "hash": {
+                    "type": "string"
+                },
+                "parentHash": {
+                    "type": "string"
+                },
+                "mixHash": {
+                    "type": "string"
+                },
+                "nonce": {
+                    "type": "string"
+                },
+                "sha3Uncles": {
+                    "type": "string"
+                },
+                "logsBloom": {
+                    "type": "string"
+                },
+                "transactionsRoot": {
+                    "type": "string"
+                },
+                "stateRoot": {
+                    "type": "string"
+                },
+                "receiptsRoot": {
+                    "type": "string"
+                },
+                "miner": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "string"
+                },
+                "totalDifficulty": {
+                    "type": "string"
+                },
+                "extraData": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "string"
+                },
+                "gasLimit": {
+                    "type": "string"
+                },
+                "gasUsed": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                },
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
                                 "type": "string"
                             },
-                            "blockNumber": {
-                                "type": "string"
-                            },
-                            "from": {
-                                "type": "string"
-                            },
-                            "gas": {
-                                "type": "string"
-                            },
-                            "gasPrice": {
-                                "type": "string"
-                            },
-                            "hash": {
-                                "type": "string"
-                            },
-                            "input": {
-                                "type": "string"
-                            },
-                            "nonce": {
-                                "type": "string"
-                            },
-                            "r": {
-                                "type": "string"
-                            },
-                            "s": {
-                                "type": "string"
-                            },
-                            "to": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
-                            },
-                            "transactionIndex": {
-                                "type": "string"
-                            },
-                            "v": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "string"
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "blockHash": {
+                                        "type": "string"
+                                    },
+                                    "blockNumber": {
+                                        "type": "string"
+                                    },
+                                    "from": {
+                                        "type": "string"
+                                    },
+                                    "gas": {
+                                        "type": "string"
+                                    },
+                                    "gasPrice": {
+                                        "type": "string"
+                                    },
+                                    "hash": {
+                                        "type": "string"
+                                    },
+                                    "input": {
+                                        "type": "string"
+                                    },
+                                    "nonce": {
+                                        "type": "string"
+                                    },
+                                    "r": {
+                                        "type": "string"
+                                    },
+                                    "s": {
+                                        "type": "string"
+                                    },
+                                    "to": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "transactionIndex": {
+                                        "type": "string"
+                                    },
+                                    "v": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                }
                             }
-                        }
+                        ]
                     }
-                ]
-            }
-        },
-        "uncles": {
-            "type": "array",
-            "items": {
-                "type": "string"
+                },
+                "uncles": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
             }
         }
-    }
+    },
+    "required": [
+        "block"
+    ]
 }

--- a/Connector/eth/rpcschemas/getblockbynumber_response.json
+++ b/Connector/eth/rpcschemas/getblockbynumber_response.json
@@ -61,54 +61,61 @@
         "transactions": {
             "type": "array",
             "items": {
-                "type": "object",
-                "properties": {
-                    "blockHash": {
+                "oneOf": [
+                    {
                         "type": "string"
                     },
-                    "blockNumber": {
-                        "type": "string"
-                    },
-                    "from": {
-                        "type": "string"
-                    },
-                    "gas": {
-                        "type": "string"
-                    },
-                    "gasPrice": {
-                        "type": "string"
-                    },
-                    "hash": {
-                        "type": "string"
-                    },
-                    "input": {
-                        "type": "string"
-                    },
-                    "nonce": {
-                        "type": "string"
-                    },
-                    "r": {
-                        "type": "string"
-                    },
-                    "s": {
-                        "type": "string"
-                    },
-                    "to": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "transactionIndex": {
-                        "type": "string"
-                    },
-                    "v": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "type": "string"
+                    {
+                        "type": "object",
+                        "properties": {
+                            "blockHash": {
+                                "type": "string"
+                            },
+                            "blockNumber": {
+                                "type": "string"
+                            },
+                            "from": {
+                                "type": "string"
+                            },
+                            "gas": {
+                                "type": "string"
+                            },
+                            "gasPrice": {
+                                "type": "string"
+                            },
+                            "hash": {
+                                "type": "string"
+                            },
+                            "input": {
+                                "type": "string"
+                            },
+                            "nonce": {
+                                "type": "string"
+                            },
+                            "r": {
+                                "type": "string"
+                            },
+                            "s": {
+                                "type": "string"
+                            },
+                            "to": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "transactionIndex": {
+                                "type": "string"
+                            },
+                            "v": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
                     }
-                }
+                ]
             }
         },
         "uncles": {

--- a/Connector/eth/utils.py
+++ b/Connector/eth/utils.py
@@ -58,3 +58,7 @@ def toWei(amount):
 
 def toHex(amount):
     return hex(amount)
+
+
+def isHexNumber(number: str):
+    return any(number.startswith(prefix) for prefix in ["0x", "0X"])

--- a/Connector/eth/websockets.py
+++ b/Connector/eth/websockets.py
@@ -135,7 +135,7 @@ class WebSocket:
                                            f"{self.config.networkName}{topics.TOPIC_SEPARATOR}"
                                            f"{topics.ADDRESS_BALANCE_TOPIC}"):
 
-            if utils.isAddressInBlock(address, block):
+            if utils.isAddressInBlock(address, block["block"]):
 
                 try:
                     balanceResponse = apirpc.getAddressBalance(

--- a/Connector/tests/btc/test_btc.py
+++ b/Connector/tests/btc/test_btc.py
@@ -523,8 +523,8 @@ def testGetTransaction():
             "transaction": {
                 "txId": expectedTransaction["txid"],
                 "txHash": expectedTransaction["hash"],
-                "blockNumber": str(expectedBlock["block"]["height"]),
-                "timestamp": str(expectedBlock["block"]["time"]),
+                "blockNumber": str(expectedBlock["height"]),
+                "timestamp": str(expectedBlock["time"]),
                 "fee": str(txDetails["fee"]),
                 "inputs": txDetails["inputs"],
                 "outputs": txDetails["outputs"],
@@ -569,8 +569,8 @@ def testGetTransactions():
                         "transaction": {
                             "txId": expectedTransaction["txid"],
                             "txHash": expectedTransaction["hash"],
-                            "blockNumber": str(expectedBlock["block"]["height"]),
-                            "timestamp": str(expectedBlock["block"]["time"]),
+                            "blockNumber": str(expectedBlock["height"]),
+                            "timestamp": str(expectedBlock["time"]),
                             "fee": str(txDetails["fee"]),
                             "inputs": txDetails["inputs"],
                             "outputs": txDetails["outputs"],

--- a/Connector/tests/btc/test_btc.py
+++ b/Connector/tests/btc/test_btc.py
@@ -170,7 +170,7 @@ def testGetBlock():
         logger.printError("getBlockByHash not loaded in RPCMethods")
         assert False
 
-    blockNumber = "1"
+    blockNumber = 1
 
     expectedHash = makeBitcoinCoreRequest(GET_BLOCK_HASH_METHOD, [blockNumber])
     expectedBlock = makeBitcoinCoreRequest(GET_BLOCK_METHOD, [expectedHash, 2])
@@ -181,7 +181,7 @@ def testGetBlock():
         logger.printError(f"Get block by hash error. Expected  {expectedBlock} but Got{gotByHash}")
         assert False
 
-    gotByNumber = RouteTableDef.httpMethods[COIN_SYMBOL]["getBlockByNumber"].handler({"blockNumber": blockNumber}, config)
+    gotByNumber = RouteTableDef.httpMethods[COIN_SYMBOL]["getBlockByNumber"].handler({"blockNumber": str(blockNumber)}, config)
 
     if not json.dumps(expectedBlock, sort_keys=True) == json.dumps(gotByNumber["block"], sort_keys=True):
         logger.printError(f"Get block by number error. Expected  {expectedBlock} but Got{gotByNumber}")
@@ -523,12 +523,8 @@ def testGetTransaction():
             "transaction": {
                 "txId": expectedTransaction["txid"],
                 "txHash": expectedTransaction["hash"],
-<<<<<<< HEAD
                 "blockNumber": str(expectedBlock["height"]),
                 "timestamp": str(expectedBlock["time"]),
-=======
-                "blockNumber": str(expectedBlock["block"]["height"]),
->>>>>>> 4cd2b63 (BTC Bug fix)
                 "fee": str(txDetails["fee"]),
                 "inputs": txDetails["inputs"],
                 "outputs": txDetails["outputs"],

--- a/Connector/tests/btc/test_btc.py
+++ b/Connector/tests/btc/test_btc.py
@@ -177,13 +177,13 @@ def testGetBlock():
 
     gotByHash = RouteTableDef.httpMethods[COIN_SYMBOL]["getBlockByHash"].handler({"blockHash": expectedHash}, config)
 
-    if not json.dumps(expectedBlock, sort_keys=True) == json.dumps(gotByHash, sort_keys=True):
+    if not json.dumps(expectedBlock, sort_keys=True) == json.dumps(gotByHash["block"], sort_keys=True):
         logger.printError(f"Get block by hash error. Expected  {expectedBlock} but Got{gotByHash}")
         assert False
 
     gotByNumber = RouteTableDef.httpMethods[COIN_SYMBOL]["getBlockByNumber"].handler({"blockNumber": blockNumber}, config)
 
-    if not json.dumps(expectedBlock, sort_keys=True) == json.dumps(gotByNumber, sort_keys=True):
+    if not json.dumps(expectedBlock, sort_keys=True) == json.dumps(gotByNumber["block"], sort_keys=True):
         logger.printError(f"Get block by number error. Expected  {expectedBlock} but Got{gotByNumber}")
         assert False
 

--- a/Connector/tests/btc/test_btc.py
+++ b/Connector/tests/btc/test_btc.py
@@ -170,7 +170,7 @@ def testGetBlock():
         logger.printError("getBlockByHash not loaded in RPCMethods")
         assert False
 
-    blockNumber = 1
+    blockNumber = "1"
 
     expectedHash = makeBitcoinCoreRequest(GET_BLOCK_HASH_METHOD, [blockNumber])
     expectedBlock = makeBitcoinCoreRequest(GET_BLOCK_METHOD, [expectedHash, 2])
@@ -523,8 +523,12 @@ def testGetTransaction():
             "transaction": {
                 "txId": expectedTransaction["txid"],
                 "txHash": expectedTransaction["hash"],
+<<<<<<< HEAD
                 "blockNumber": str(expectedBlock["height"]),
                 "timestamp": str(expectedBlock["time"]),
+=======
+                "blockNumber": str(expectedBlock["block"]["height"]),
+>>>>>>> 4cd2b63 (BTC Bug fix)
                 "fee": str(txDetails["fee"]),
                 "inputs": txDetails["inputs"],
                 "outputs": txDetails["outputs"],

--- a/Connector/tests/btc/test_btc.py
+++ b/Connector/tests/btc/test_btc.py
@@ -523,8 +523,8 @@ def testGetTransaction():
             "transaction": {
                 "txId": expectedTransaction["txid"],
                 "txHash": expectedTransaction["hash"],
-                "blockNumber": str(expectedBlock["height"]),
-                "timestamp": str(expectedBlock["time"]),
+                "blockNumber": str(expectedBlock["block"]["height"]),
+                "timestamp": str(expectedBlock["block"]["time"]),
                 "fee": str(txDetails["fee"]),
                 "inputs": txDetails["inputs"],
                 "outputs": txDetails["outputs"],
@@ -569,8 +569,8 @@ def testGetTransactions():
                         "transaction": {
                             "txId": expectedTransaction["txid"],
                             "txHash": expectedTransaction["hash"],
-                            "blockNumber": str(expectedBlock["height"]),
-                            "timestamp": str(expectedBlock["time"]),
+                            "blockNumber": str(expectedBlock["block"]["height"]),
+                            "timestamp": str(expectedBlock["block"]["time"]),
                             "fee": str(txDetails["fee"]),
                             "inputs": txDetails["inputs"],
                             "outputs": txDetails["outputs"],

--- a/Connector/tests/eth/test_eth.py
+++ b/Connector/tests/eth/test_eth.py
@@ -196,7 +196,7 @@ def testGetTransaction():
     assert got["transaction"]["fee"] == str(utils.toWei(expected["gas"]) * utils.toWei(expected["gasPrice"]))
     assert got["transaction"]["blockHash"] == expected["blockHash"]
     assert got["transaction"]["blockNumber"] == str(int(expected["blockNumber"], 16))
-    assert got["transaction"]["timestamp"] == str(int(expectedBlock["timestamp"], 16))
+    assert got["transaction"]["timestamp"] == str(int(expectedBlock["block"]["timestamp"], 16))
     assert json.dumps(got["transaction"]["data"], sort_keys=True) == json.dumps(expected, sort_keys=True)
     assert json.dumps(got["transaction"]["inputs"][0], sort_keys=True) == json.dumps(
         {
@@ -246,7 +246,7 @@ def testGetTransactions():
                     utils.toWei(expected["gas"]) * utils.toWei(expected["gasPrice"]))
                 assert gotTransaction["transaction"]["blockHash"] == expected["blockHash"]
                 assert gotTransaction["transaction"]["blockNumber"] == str(int(expected["blockNumber"], 16))
-                assert gotTransaction["transaction"]["timestamp"] == str(int(expectedBlock["timestamp"], 16))
+                assert gotTransaction["transaction"]["timestamp"] == str(int(expectedBlock["block"]["timestamp"], 16))
                 assert json.dumps(gotTransaction["transaction"]["data"], sort_keys=True) == json.dumps(expected, sort_keys=True)
                 assert json.dumps(gotTransaction["transaction"]["inputs"][0], sort_keys=True) == json.dumps(
                     {

--- a/Connector/tests/eth/test_eth.py
+++ b/Connector/tests/eth/test_eth.py
@@ -406,11 +406,11 @@ def testGetBlock():
 
     gotBlockByHash = RouteTableDef.httpMethods[COIN_SYMBOL]["getBlockByHash"].handler({"blockHash": expected["hash"]}, config)
 
-    if not json.dumps(expected["transactions"], sort_keys=True) == json.dumps(gotBlockByNumber["transactions"], sort_keys=True):
+    if not json.dumps(expected["transactions"], sort_keys=True) == json.dumps(gotBlockByNumber["block"]["transactions"], sort_keys=True):
         logger.printError("getBlockByNumber failed")
         assert False
 
-    if not json.dumps(expected["transactions"], sort_keys=True) == json.dumps(gotBlockByHash["transactions"], sort_keys=True):
+    if not json.dumps(expected["transactions"], sort_keys=True) == json.dumps(gotBlockByHash["block"]["transactions"], sort_keys=True):
         logger.printError("getBlockByHash failed")
         assert False
 

--- a/Connector/tests/eth/test_eth.py
+++ b/Connector/tests/eth/test_eth.py
@@ -196,7 +196,7 @@ def testGetTransaction():
     assert got["transaction"]["fee"] == str(utils.toWei(expected["gas"]) * utils.toWei(expected["gasPrice"]))
     assert got["transaction"]["blockHash"] == expected["blockHash"]
     assert got["transaction"]["blockNumber"] == str(int(expected["blockNumber"], 16))
-    assert got["transaction"]["timestamp"] == str(int(expectedBlock["block"]["timestamp"], 16))
+    assert got["transaction"]["timestamp"] == str(int(expectedBlock["timestamp"], 16))
     assert json.dumps(got["transaction"]["data"], sort_keys=True) == json.dumps(expected, sort_keys=True)
     assert json.dumps(got["transaction"]["inputs"][0], sort_keys=True) == json.dumps(
         {

--- a/Connector/tests/eth/test_eth.py
+++ b/Connector/tests/eth/test_eth.py
@@ -246,7 +246,7 @@ def testGetTransactions():
                     utils.toWei(expected["gas"]) * utils.toWei(expected["gasPrice"]))
                 assert gotTransaction["transaction"]["blockHash"] == expected["blockHash"]
                 assert gotTransaction["transaction"]["blockNumber"] == str(int(expected["blockNumber"], 16))
-                assert gotTransaction["transaction"]["timestamp"] == str(int(expectedBlock["block"]["timestamp"], 16))
+                assert gotTransaction["transaction"]["timestamp"] == str(int(expectedBlock["timestamp"], 16))
                 assert json.dumps(gotTransaction["transaction"]["data"], sort_keys=True) == json.dumps(expected, sort_keys=True)
                 assert json.dumps(gotTransaction["transaction"]["inputs"][0], sort_keys=True) == json.dumps(
                     {


### PR DESCRIPTION
# Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

Changes:
- BTC, BCH and ETH `getBlockByNumber` methods support latest param
- ETH `getBlockByNumber` support verbosity mode
- BTC, BCH and ETH `getBlockByNumber` response is embedded is `block` field

Fixes #169 

## Dependencies (if any)

<!--List any dependencies that are required for this change.-->

None

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **This change requires a documentation update**

# How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. -->
<!--Provide instructions so we can reproduce the changes, if possible add screenshots, gifs or logs to facilitate the work.-->
<!--Please also list any relevant details for your test configuration.-->

- ETH getBlockByNumber with `latest` param
   ```sh
   curl --location --request POST 'http://localhost:80/eth/testnet/rpc' \
   --header 'Content-Type: application/json' \
   --data-raw '{
       "id": 1652624648,
       "method": "getBlockByNumber",
       "params": {
           "blockNumber": "latest"
       },
       "jsonrpc": "2.0"
   }'
   ```
   ```js
   {
       "id": 1652624644,
       "jsonrpc": "2.0",
       "result": {
           "block": {
               "baseFeePerGas": "0xe7e4a17",
               "difficulty": "0x14c828a96",
               "extraData": "0xd783010a11846765746886676f312e31388664617277696e",
               "gasLimit": "0x7a1200",
               "gasUsed": "0x58a61b",
               "hash": "0xb70428bbdbbf576a4a628f71601aaaada73e00d83a9f4d0bed5cf47c108f3de2",
               "logsBloom": "0x00001000000000000002000004000000000000008000000000002000000100800000000000010000000000000000020000040000048000000020000000200000000000010000000000000008022000000000000000800000400800000000000000000000020000880000000000004800000014000010008000000010000000000004000008000000000200000000042000000000000001000000202020800000020000000100000800000000000000000000100000000080000000001004000202000002000000040200000000000001000000008080000000000000000020000010000000002000000000002040000000000000000200000000000040000000",
               "miner": "0x32bb9565e0b981858e56b4ce23d46efeb1fc0d8b",
               "mixHash": "0xa9855d8b0af60c3888e5726ef7ac9a528ed618fbb9a59103275c6b34080aab36",
               "nonce": "0x5e2abaed52621d15",
               "number": "0xbb2b5c",
               "parentHash": "0xe0b78b48ffc1a1485cda12383fe1e084e3506109c4366d4567bcc8d784380208",
               "receiptsRoot": "0xca5979921312f212635d2593b648420326b6583eb7579ccdc32422e8df823541",
               "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
               "size": "0x65a4",
               "stateRoot": "0x808697e926c666b446f6a3fb5baec97456fa32486fa9dbc43f7712615e5529ab",
               "timestamp": "0x62810ced",
               "totalDifficulty": "0x9454112b807311",
               "transactions": [
                   {
                       "accessList": [],
                       "blockHash": "0xb70428bbdbbf576a4a628f71601aaaada73e00d83a9f4d0bed5cf47c108f3de2",
                       "blockNumber": "0xbb2b5c",
                       "chainId": "0x3",
                       "from": "0x9c71fbe2d28080b8afa88cea8a1e319de2c09d44",
                       "gas": "0x1f75f0",
                       "gasPrice": "0x174876e800",
                       "hash": "0x5b7feaf9cd7186e111d2999a201b833d812276ae65682750f2de26af213b31ac",
                       "input": "0xcd51b0930000000000000000000000000000000000000000000000008ac7230489e80000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000280000000000000000000000000e56e01ae5193b9a2d87241efd71700ea0be2bca000000000000000000000000a2e87817bcd1629ce64a8d5a78bd11d5f6d8368d00000000000000000000000081feb615710874e9426b775d33ae8ac789ba1e8c00000000000000000000000001ba8e97e759eac1873a50f5ce31c175f277c96f000000000000000000000000d942da82d20729180405fb65fe5ed4b795dc99600000000000000000000000000485c041a5bb7cac9c3fa66551ea52d12a082e1f000000000000000000000000bf55a400565705f55f05be51ca4fba11452c38e6000000000000000000000000fab8a944fe0ee4361048bd2f8444b91a297431f40000000000000000000000008d0fed88b9889c531b1c65350963ffb85f2fcb690000000000000000000000007b7bde1ee9f84a9c1f98378f7e8c211053b55e4f000000000000000000000000813556c213da01ff8185641d57e607331b84e050000000000000000000000000a92b64f91886522f9b2387c9b6df213f9b4e823200000000000000000000000005c093c0fe73d358427d264ef5af6b4c1a6dc59c000000000000000000000000dc5a8b8199ea84868cea180e4ce2062c903b442c0000000000000000000000002f638ffd89cae6edd9381be84fed5b4dd17c6150000000000000000000000000cc06fb6aba485d97155cfdb616e8dbb2809a5f0700000000000000000000000017b2f222d4a7f93573f736822dcd5f02b2b9b4770000000000000000000000008f36639f4e125ea2c95c73c842cd4eb083325db5000000000000000000000000387ab9264656d598e6bf6f272cdbac173ac314a90000000000000000000000001660be67df790f5f8a06cc43d82a6322306c33850000000000000000000000001cee6695328297f39be91a7b3f8c0a6f5f9bde2b000000000000000000000000529994e35e6fe8085c0d6ecfd5b32e9ed4d1a2c300000000000000000000000001a813269c7b355cce7f066c577dd3297a9c38c1000000000000000000000000d8184c3aa6620d256b3fefdea70c101ae5eee09b000000000000000000000000adb0c89a1b41188b09c67557b8fef6dd969db8910000000000000000000000005be083d48adb4430e59080e31c046a1ecde0d01d0000000000000000000000009fdff7fb4007176afdf7477157a3efebf19fc462000000000000000000000000a4633b3501ec855cc2e331bebab45b3334446564000000000000000000000000aa2b6528ba4587bd5c7896ad8b9b4c8ea7aae974000000000000000000000000d23412d39b638d351775c91471fa76f446addc540000000000000000000000009398bedb52e84900e0d94c0a78beeba2ba2b8e92000000000000000000000000d07600fb06e002b3f360133b3eeeb4bf33bf1e480000000000000000000000006710b6e6d51c0dfed9da0733b22a848503913f2a000000000000000000000000bf471cdcebbae980dadf0ace52b92949c34f5254000000000000000000000000d5a0ecc13bfff055e647c41747d75f704296ae63000000000000000000000000ff1d13356e2b6bd22a744c418ab6ca6a3b80e329000000000000000000000000ddd7dff38ee2c805262a5c4535f128d62f277b540000000000000000000000007b6e1ff608a1869e73986962b0a0abf2524c45e4000000000000000000000000d83f3d0a8d38c061700616e0904c4709167ca29d0000000000000000000000001f58b34c8c7aa63ddec4cbecce4ce5686a2fffab",
                       "maxFeePerGas": "0x174876e800",
                       "maxPriorityFeePerGas": "0x174876e800",
                       "nonce": "0x4a63",
                       "r": "0xce5751f95648c50442befda8658eb1415b75dcce711bc518b4b29a183f61f5a",
                       "s": "0x2f98eb953006b9f18ee32cc8e3c05a1b443e8591b2dcba7e40130f4107d69fa4",
                       "to": "0x7917a2f6c13e1e13452f0d52157e5afad999d36b",
                       "transactionIndex": "0x0",
                       "type": "0x2",
                       "v": "0x0",
                       "value": "0x0"
                   }
               ],
               "transactionsRoot": "0xc72c225042f0a8e3c697d25b1129064fc32466dc5776eda745b0e6fa8381aa1a",
               "uncles": []
           }
       }
   }
   ```
- BTC getBlockByNumber with `latest` param
  ```sh
  curl --location --request POST 'http://localhost:80/btc/regtest/rpc' \
   --header 'Content-Type: application/json' \
   --data-raw '{
       "id": 1652625159,
       "method": "getBlockByNumber",
       "params": {
           "blockNumber": "latest"
       },
       "jsonrpc": "2.0"
  }'
  ```
  ```js
  {
       "id": 1652625157,
       "jsonrpc": "2.0",
       "result": {
           "block": {
               "hash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
               "confirmations": 1,
               "strippedsize": 285,
               "size": 285,
               "weight": 1140,
               "height": 0,
               "version": 1,
               "versionHex": "00000001",
               "merkleroot": "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
               "tx": [
                   {
                       "txid": "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
                       "hash": "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
                       "version": 1,
                       "size": 204,
                       "vsize": 204,
                       "weight": 816,
                       "locktime": 0,
                       "vin": [
                           {
                               "coinbase": "04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73",
                               "sequence": 4294967295
                           }
                       ],
                       "vout": [
                           {
                               "value": 50.0,
                               "n": 0,
                               "scriptPubKey": {
                                   "asm": "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f OP_CHECKSIG",
                                   "hex": "4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac",
                                   "type": "pubkey"
                               }
                           }
                       ],
                       "hex": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000"
                   }
               ],
               "time": 1296688602,
               "mediantime": 1296688602,
               "nonce": 2,
               "bits": "207fffff",
               "difficulty": 4.656542373906925e-10,
               "chainwork": "0000000000000000000000000000000000000000000000000000000000000002",
               "nTx": 1
           }
       }
  }
  ```
- ETH getblockByNumber with verbosity mode
   ```sh
   curl --location --request POST 'http://localhost:80/eth/testnet/rpc' \
   --header 'Content-Type: application/json' \
   --data-raw '{
       "id": 1652624866,
       "method": "getBlockByNumber",
       "params": {
           "blockNumber": "latest",
           "verbosity": 1
       },
       "jsonrpc": "2.0"
   }'
   ```
   ```js
   {
       "id": 1652624865,
       "jsonrpc": "2.0",
       "result": {
           "block": {
               "baseFeePerGas": "0x11b44731",
               "difficulty": "0x14ddbb9c3",
               "extraData": "0x",
               "gasLimit": "0x7a1200",
               "gasUsed": "0x79d6ac",
               "hash": "0xca9f1a96b3bea3e39c4fe9baf971bd74665912dcfbf6b8d716acdcaa28fd45cc",
               "logsBloom": "0x0030000000000001982800000400000000000000008004a040000000001000800032000000210010010404100500040000000580008400200000400100a00100110020010002200d0120000822000000100808000200000000140240000200000201000203000002900000890000082020000002040000000000005000010100000002440020010010000200800000200c0001022000002800000000880040024200800004000000b04400000000000040028c090004092002000008010508000000800a084042061300000000000008100000001400000002000000001420004090200800082820809004000000004000008809004080000011080080018110",
               "miner": "0x6784daf320b7ffb5333a57d2418b49365cc60985",
               "mixHash": "0x56bc3abf80f3cb0dafacd5a4ffa3ffdb2ef7ff10db24f89d9fb02bd09688f302",
               "nonce": "0x000009e25c6dbd06",
               "number": "0xbb2b60",
               "parentHash": "0x75cb8d686beddf6ff24a8d985a91c5017d8ebfbf0e4d68ddae5fd32d444b263e",
               "receiptsRoot": "0xdf87f286f2d5e59be4c0c744c382b2207ab8c2f962f26c35305029273fa16ecc",
               "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
               "size": "0x852a",
               "stateRoot": "0x9ec5c8921c655809bbd09aea80abd23433748faa2cd8c9cac60035326c901774",
               "timestamp": "0x62810d46",
               "totalDifficulty": "0x945416613cf221",
               "transactions": [
                   "0x9cb3aa107b166a3d1153dc11a48418100fdb519417097c27dd3d1af03d277c48"
               ],
               "transactionsRoot": "0xa0aab6ee2a3a0dd55d60bc62d3cfb8ff08b08b77fee591c173cd20eeb2bfde4f",
               "uncles": []
            }
       }
   }
   ```
**Test Configuration**:
* Operating system (output of `sw_vers`): macOS 12.3.1
* Kernel version (output of `uname -sr`): Darwin 21.4.0
* Architecture (output of `uname -m`): x86_64

# Related PR or Docs PR

<!--Please add any related Pull Requests here. -->
Docs PR related # <!--(if any)-->
Other PR related # <!--(if any)-->

# Good practices to consider

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules