### PR TITLE
(ERC-20) Get Address Balance async

### DIFF
--- a/Connector/eth/erc20/apirpc.py
+++ b/Connector/eth/erc20/apirpc.py
@@ -46,20 +46,29 @@ async def getAddressBalance(id, params, config):
     )
 
     response = {}
+    tasks = []
 
     for contractAddress in params["contractAddresses"]:
 
-        result = await ethapirpc.call(
-            id=id,
-            params={
-                "transaction": {
-                    "to": contractAddress,
-                    "data": data
-                },
-                "blockNumber": "latest"
-            },
-            config=config
+        tasks.append(
+            asyncio.ensure_future(
+                ethapirpc.call(
+                    id=id,
+                    params={
+                        "transaction": {
+                            "to": contractAddress,
+                            "data": data
+                        },
+                        "blockNumber": "latest"
+                    },
+                    config=config
+                )
+            )
         )
+
+    results = await asyncio.gather(*tasks)
+
+    for contractAddress, result in zip(params["contractAddresses"], results):
 
         response[contractAddress] = {
             "address": params["address"],


### PR DESCRIPTION
# Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.-->

Fixes #231  (issue)

## Dependencies (if any)

<!--List any dependencies that are required for this change.-->

## Type of change

<!--Please delete options that are not relevant.-->

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **This change requires a documentation update**

# How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. -->
<!--Provide instructions so we can reproduce the changes, if possible add screenshots, gifs or logs to facilitate the work.-->
<!--Please also list any relevant details for your test configuration.-->

- Get Addresses Balance
   ```sh
   curl --location --request POST 'http://localhost:80/eth/testnet/erc20/rpc' \
   --header 'Content-Type: application/json' \
   --data-raw '{
       "params": {
           "addresses": [
               "0xf1d153a64c509ac54e09d5821e08486356e39816"
           ],
           "contractAddresses": [
               "0x5F1f5039f95c347eB37fB650BC33800cEf5C99Ef",
               "0x8626db1a4f9f3e1002eeb9a4f3c6d391436ffc23",
               "0x61A41e578500F2f62810a14B0B449391E511aeb8",
               "0xba9ca9560FAaD32b8672f2c9a714fFe3BD48acF3",
               "0x43ddB3468C4B9fCb9fF8F8C64AfEC7d4a7D30f59",
               "0xa176a2e1B0b9C9291365efFC02c5602CbbEBeBC8",
               "0x2A7cb24cC11B29B7EaE6715Fc038B6A2Bc63Ac2D",
               "0x28D420B4fF0cB8750B94bafe51A272c297Bd91a6",
               "0xABE547E86F7063BBf4e2DDd22CAABb2a16004537",
               "0x1528C5e977FAC36B31136bD27cb7da4C5598537F"
            ]
       },
       "method": "getAddressesBalance",
       "id": 1,
       "jsonrpc": "2.0"
   }'
   ```
   ```js
    {
        "id": 1,
        "jsonrpc": "2.0",
        "result": {
            "0x5F1f5039f95c347eB37fB650BC33800cEf5C99Ef": [
                {
                    "address": "0xf1d153a64c509ac54e09d5821e08486356e39816",
                    "balance": {
                        "confirmed": "50000000",
                        "unconfirmed": "0"
                    }
                }
            ],
            "0x8626db1a4f9f3e1002eeb9a4f3c6d391436ffc23": [
                {
                    "address": "0xf1d153a64c509ac54e09d5821e08486356e39816",
                    "balance": {
                        "confirmed": "74372630000000000",
                        "unconfirmed": "0"
                    }
                }
            ],
            "0x61A41e578500F2f62810a14B0B449391E511aeb8": [
                {
                    "address": "0xf1d153a64c509ac54e09d5821e08486356e39816",
                    "balance": {
                        "confirmed": "0",
                        "unconfirmed": "0"
                    }
                }
            ],
            "0xba9ca9560FAaD32b8672f2c9a714fFe3BD48acF3": [
                {
                    "address": "0xf1d153a64c509ac54e09d5821e08486356e39816",
                    "balance": {
                        "confirmed": "0",
                        "unconfirmed": "0"
                    }
                }
            ],
            "0x43ddB3468C4B9fCb9fF8F8C64AfEC7d4a7D30f59": [
                {
                    "address": "0xf1d153a64c509ac54e09d5821e08486356e39816",
                    "balance": {
                        "confirmed": "0",
                        "unconfirmed": "0"
                    }
                }
            ],
            "0xa176a2e1B0b9C9291365efFC02c5602CbbEBeBC8": [
                {
                    "address": "0xf1d153a64c509ac54e09d5821e08486356e39816",
                    "balance": {
                        "confirmed": "0",
                        "unconfirmed": "0"
                    }
                }
            ],
            "0x2A7cb24cC11B29B7EaE6715Fc038B6A2Bc63Ac2D": [
                {
                    "address": "0xf1d153a64c509ac54e09d5821e08486356e39816",
                    "balance": {
                        "confirmed": "0",
                        "unconfirmed": "0"
                    }
                }
            ],
            "0x28D420B4fF0cB8750B94bafe51A272c297Bd91a6": [
                {
                    "address": "0xf1d153a64c509ac54e09d5821e08486356e39816",
                    "balance": {
                        "confirmed": "0",
                        "unconfirmed": "0"
                    }
                }
            ],
            "0xABE547E86F7063BBf4e2DDd22CAABb2a16004537": [
                {
                    "address": "0xf1d153a64c509ac54e09d5821e08486356e39816",
                    "balance": {
                        "confirmed": "0",
                        "unconfirmed": "0"
                    }
                }
            ],
            "0x1528C5e977FAC36B31136bD27cb7da4C5598537F": [
                {
                    "address": "0xf1d153a64c509ac54e09d5821e08486356e39816",
                    "balance": {
                        "confirmed": "0",
                        "unconfirmed": "0"
                    }
                }
            ]
        }
    }
   ```


**Test Configuration**:
* Operating system (output of `cat /etc/os-release`): macOs 12.5
* Kernel version (output of `uname -sr`): Darwin 21.6.0
* Architecture (output of `uname -m`): x86_64

# Related PR or Docs PR

<!--Please add any related Pull Requests here. -->
Docs PR related # <!--(if any)-->
Other PR related # <!--(if any)-->

# Good practices to consider

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules